### PR TITLE
Added a table with cumulative liquidable debt to the dashboard

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,6 +7,7 @@ import time
 
 import numpy.random
 import pandas
+import pandas
 import plotly.express
 import streamlit
 
@@ -205,7 +206,7 @@ def process_liquidity(main_chart_data: pandas.DataFrame, collateral_token: str, 
     return main_chart_data, collateral_token_price
 
 
-def create_accumulated_debt(data):
+def create_accumulated_debt(data: pandas.DataFrame) -> pandas.DataFrame:
     """Create a DataFrame with cumulative liquidable debt and flip the cumulative column."""
     accumulated_debt = data[['collateral_token_price', 'liquidable_debt']].copy()
     accumulated_debt['Cumulative_liquidable_debt'] = accumulated_debt['liquidable_debt'].cumsum()
@@ -213,10 +214,14 @@ def create_accumulated_debt(data):
     accumulated_debt['Cumulative_liquidable_debt'] = accumulated_debt['Cumulative_liquidable_debt'].iloc[::-1].values
     return accumulated_debt
 
-def filter_by_price_range(data, price_column, price_min, price_max):
+def filter_by_price_range(
+    data: pandas.DataFrame, 
+    price_column: str, 
+    price_min: float, 
+    price_max: float
+) -> pandas.DataFrame:
     """Filter the DataFrame based on a price range."""
     return data[data[price_column].between(price_min, price_max)]
-
 
 def main():
     streamlit.title("DeRisk")
@@ -397,7 +402,8 @@ def main():
     # Display the filtered DataFrame and hide the index
     streamlit.dataframe(
         filtered_accumulated_debt[['collateral_token_price', 'liquidable_debt', 'Cumulative_liquidable_debt']],
-        use_container_width=True
+        use_container_width=True,
+        hide_index=True
     )
 
     streamlit.header("Loans with low health factor")

--- a/app.py
+++ b/app.py
@@ -353,6 +353,35 @@ def main():
             f" worth of {int(example_row['liquidable_debt_at_interval']):,} USD will be liquidated while the AMM swaps "
             f"capacity will be {int(example_row['debt_token_supply']):,} USD."
         )
+    accumulated_debt = main_chart_data[['collateral_token_price', 'liquidable_debt']].copy()
+    accumulated_debt['accumulated_liquidable_debt'] = accumulated_debt['liquidable_debt'].cumsum()
+    accumulated_debt['accumulated_liquidable_debt'] = accumulated_debt['accumulated_liquidable_debt'].iloc[::-1].values
+
+    # Streamlit header
+    streamlit.header("Accumulated Liquidable Debt by Collateral Price")
+
+    # two columns  layout
+    col1, _ = streamlit.columns([1, 3])
+
+    # slider with 1 column
+    with col1:
+        price_lower_bound, price_upper_bound = streamlit.slider(
+            label="Select range of Collateral Token Price",
+            min_value=float(accumulated_debt["collateral_token_price"].min()),
+            max_value=float(accumulated_debt["collateral_token_price"].max()),
+            value=(float(accumulated_debt["collateral_token_price"].min()), float(accumulated_debt["collateral_token_price"].max())),
+        )
+
+    # Filter the accumulated_debt DataFrame based on the selected price range
+    filtered_accumulated_debt = accumulated_debt[
+        accumulated_debt["collateral_token_price"].between(price_lower_bound, price_upper_bound)
+    ]
+
+    # Display the filtered DataFrame with the accumulated liquidable debt column
+    streamlit.dataframe(
+        filtered_accumulated_debt[['collateral_token_price', 'liquidable_debt', 'accumulated_liquidable_debt']],
+        use_container_width=True
+    )
 
     streamlit.header("Loans with low health factor")
     col1, _ = streamlit.columns([1, 3])

--- a/app.py
+++ b/app.py
@@ -355,7 +355,6 @@ def main():
         )
 
     streamlit.header("Liquidable debt")
-    # Create two columns for layout
     liquidable_debt_data = main_chart_data[['collateral_token_price', 'liquidable_debt_at_interval', 'liquidable_debt']].copy()
     liquidable_debt_data.rename(columns={'liquidable_debt': 'Liquidable debt at price','liquidable_debt_at_interval':'Liquidable debt at interval','collateral_token_price':'Collateral token price'}, inplace=True)
 

--- a/app.py
+++ b/app.py
@@ -217,7 +217,7 @@ def filter_by_price_range(data, price_column, price_min, price_max):
     """Filter the DataFrame based on a price range."""
     return data[data[price_column].between(price_min, price_max)]
 
-    
+
 def main():
     streamlit.title("DeRisk")
 
@@ -367,7 +367,7 @@ def main():
             f" worth of {int(example_row['liquidable_debt_at_interval']):,} USD will be liquidated while the AMM swaps "
             f"capacity will be {int(example_row['debt_token_supply']):,} USD."
         )
-  # accumulated liqudable debt table tobe
+  # accumulated liqudable debt table 
     streamlit.header("Cumulative Liquidable Debt by Collateral Price")
 
     # Create accumulated debt DataFrame

--- a/app.py
+++ b/app.py
@@ -354,11 +354,8 @@ def main():
             f"capacity will be {int(example_row['debt_token_supply']):,} USD."
         )
 
-
     streamlit.header("Liquidable debt")
-
     # Create two columns for layout
-    col1, _ = streamlit.columns([1, 3])
     liquidable_debt_data = main_chart_data[['collateral_token_price', 'liquidable_debt_at_interval', 'liquidable_debt']].copy()
     liquidable_debt_data.rename(columns={'liquidable_debt': 'Liquidable debt at price','liquidable_debt_at_interval':'Liquidable debt at interval','collateral_token_price':'Collateral token price'}, inplace=True)
 


### PR DESCRIPTION
Fix #187 
Features added

1.Created a new DataFrame, accumulated_debt, that calculates the cumulative sum of liquidable debt.
2.Added a Streamlit header for "Accumulated Liquidable Debt by Collateral Price."
3.Implemented a slider to allow users to select a range of collateral token prices.
4.Filtered the accumulated debt data based on the selected price range.
5.Displayed the filtered data, showing collateral token price, liquidable debt, and accumulated liquidable debt in a table.