### PR TITLE
test: DeRiskAPIConnector initializes and gets data

### DIFF
--- a/data_handler/tests/test_api_connector.py
+++ b/data_handler/tests/test_api_connector.py
@@ -1,0 +1,61 @@
+import os
+import unittest
+from unittest.mock import patch, MagicMock
+from requests.exceptions import RequestException
+from handler_tools.api_connector import DeRiskAPIConnector
+
+class TestDeRiskAPIConnector(unittest.TestCase):
+    @patch.dict(os.environ, {"DERISK_API_URL": "https://api.derisk.io"})
+    def test_api_connector_instantiates_successfully(self):
+        """Test that DeRiskAPIConnector initializes correctly when the API URL is set."""
+        connector = DeRiskAPIConnector()
+        self.assertEqual(connector.api_url, "https://api.derisk.io")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_api_connector_raises_value_error_exception(self):
+        """Test that DeRiskAPIConnector raises a ValueError when the API URL is not set."""
+        with self.assertRaises(ValueError):
+            DeRiskAPIConnector()
+
+    @patch.dict(os.environ, {"DERISK_API_URL": "https://api.derisk.io"})
+    @patch('requests.get')
+    def test_get_data_returns_some_data(self, mock_get):
+        """Test that DeRiskAPIConnector.get_data() returns data when the response is successful."""
+        # Mock positive response
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {"status": "success", "data": "some_data"}
+        mock_get.return_value = mock_response
+
+        connector = DeRiskAPIConnector()
+        result = connector.get_data(
+            '0x04c0a5193d58f74fbace4b74dcf65481e734ed1714121bdc571da345540efa05',
+            630000,
+            631000
+        )
+
+        self.assertEqual(result, {"status": "success", "data": "some_data"})
+        mock_get.assert_called_once_with(
+            "https://api.derisk.io",
+            params={
+                "from_address": '0x04c0a5193d58f74fbace4b74dcf65481e734ed1714121bdc571da345540efa05',
+                "min_block_number": 630000,
+                "max_block_number": 631000
+            }
+        )
+
+        @patch.dict(os.environ, {"DERISK_API_URL": "https://api.derisk.io"})
+        @patch('requests.get')
+        def test_get_data_negative(self, mock_get):
+            """Test that DeRiskAPIConnector.get_data() handles request exceptions properly."""
+            # Mock negative response
+            mock_get.side_effect = RequestException("Network error")
+
+            connector = DeRiskAPIConnector()
+            result = connector.get_data(
+                '0x04c0a5193d58f74fbace4b74dcf65481e734ed1714121bdc571da345540efa05',
+                630000,
+                631000
+            )
+
+            self.assertEqual(result, {"error": "Network error"})

--- a/data_handler/tests/test_api_connector.py
+++ b/data_handler/tests/test_api_connector.py
@@ -1,15 +1,17 @@
 import os
 import unittest
 from unittest.mock import patch, MagicMock
-from requests.exceptions import RequestException
+from requests.exceptions import HTTPError
 from handler_tools.api_connector import DeRiskAPIConnector
 
 class TestDeRiskAPIConnector(unittest.TestCase):
-    @patch.dict(os.environ, {"DERISK_API_URL": "https://api.derisk.io"})
+    DERISK_API_URL = "https://api.derisk.io"
+
+    @patch.dict(os.environ, {"DERISK_API_URL": DERISK_API_URL})
     def test_api_connector_instantiates_successfully(self):
         """Test that DeRiskAPIConnector initializes correctly when the API URL is set."""
         connector = DeRiskAPIConnector()
-        self.assertEqual(connector.api_url, "https://api.derisk.io")
+        self.assertEqual(connector.api_url, self.DERISK_API_URL)
 
     @patch.dict(os.environ, {}, clear=True)
     def test_api_connector_raises_value_error_exception(self):
@@ -17,14 +19,29 @@ class TestDeRiskAPIConnector(unittest.TestCase):
         with self.assertRaises(ValueError):
             DeRiskAPIConnector()
 
-    @patch.dict(os.environ, {"DERISK_API_URL": "https://api.derisk.io"})
+    def _mock_response(self, status=200,
+            content="CONTENT",
+            json_data=None,
+            raise_for_status=None):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        if raise_for_status:
+            mock_resp.raise_for_status.side_effect = raise_for_status
+        mock_resp.status_code = status
+        mock_resp.content = content
+        if json_data:
+            mock_resp.json = MagicMock(
+                return_value=json_data
+            )
+        return mock_resp
+    
+    @patch.dict(os.environ, {"DERISK_API_URL": DERISK_API_URL})
     @patch('requests.get')
     def test_get_data_returns_some_data(self, mock_get):
         """Test that DeRiskAPIConnector.get_data() returns data when the response is successful."""
         # Mock positive response
-        mock_response = MagicMock()
-        mock_response.raise_for_status.return_value = None
-        mock_response.json.return_value = {"status": "success", "data": "some_data"}
+        json_data = {"status": "success", "data": "some_data"}
+        mock_response = self._mock_response(json_data=json_data)
         mock_get.return_value = mock_response
 
         connector = DeRiskAPIConnector()
@@ -34,9 +51,9 @@ class TestDeRiskAPIConnector(unittest.TestCase):
             631000
         )
 
-        self.assertEqual(result, {"status": "success", "data": "some_data"})
+        self.assertEqual(result, json_data)
         mock_get.assert_called_once_with(
-            "https://api.derisk.io",
+            self.DERISK_API_URL,
             params={
                 "from_address": '0x04c0a5193d58f74fbace4b74dcf65481e734ed1714121bdc571da345540efa05',
                 "min_block_number": 630000,
@@ -44,18 +61,80 @@ class TestDeRiskAPIConnector(unittest.TestCase):
             }
         )
 
-        @patch.dict(os.environ, {"DERISK_API_URL": "https://api.derisk.io"})
-        @patch('requests.get')
-        def test_get_data_negative(self, mock_get):
-            """Test that DeRiskAPIConnector.get_data() handles request exceptions properly."""
-            # Mock negative response
-            mock_get.side_effect = RequestException("Network error")
+    @patch.dict(os.environ, {"DERISK_API_URL": DERISK_API_URL})
+    @patch('requests.get')
+    def test_get_data_negative(self, mock_get):
+        """Test that DeRiskAPIConnector.get_data() handles request exceptions properly."""
+        # Mock negative response
+        mock_response = self._mock_response(raise_for_status=500)
+        mock_get.return_value = mock_response
 
-            connector = DeRiskAPIConnector()
-            result = connector.get_data(
+        connector = DeRiskAPIConnector()
+
+        with self.assertRaises(HTTPError):
+            connector.get_data(
                 '0x04c0a5193d58f74fbace4b74dcf65481e734ed1714121bdc571da345540efa05',
                 630000,
                 631000
             )
 
-            self.assertEqual(result, {"error": "Network error"})
+
+    @patch.dict(os.environ, {"DERISK_API_URL": DERISK_API_URL})
+    @patch('requests.get')
+    def test_get_data_failure_min_block_number(self, mock_get):
+        """Test that data retrieval fails when min_block_number is None or a string"""
+        connector = DeRiskAPIConnector()
+
+        with self.assertRaises(TypeError):
+            connector.get_data(
+                from_address='0x04c0a5193d58f74fbace4b74dcf65481e734ed1714121bdc571da345540efa05',
+                min_block_number=None,
+                max_block_number=631000
+            )
+
+        with self.assertRaises(TypeError):
+            connector.get_data(
+                from_address='0x04c0a5193d58f74fbace4b74dcf65481e734ed1714121bdc571da345540efa05',
+                min_block_number="invalid",
+                max_block_number=631000
+            )
+
+    @patch.dict(os.environ, {"DERISK_API_URL": DERISK_API_URL})
+    @patch('requests.get')
+    def test_get_data_failure_max_block_number(self, mock_get):
+        """Test that data retrieval fails when max_block_number is None or a string"""
+        connector = DeRiskAPIConnector()
+
+        with self.assertRaises(TypeError):
+            connector.get_data(
+                from_address='0x04c0a5193d58f74fbace4b74dcf65481e734ed1714121bdc571da345540efa05',
+                min_block_number=630000,
+                max_block_number=None
+            )
+
+        with self.assertRaises(TypeError):
+            connector.get_data(
+                from_address='0x04c0a5193d58f74fbace4b74dcf65481e734ed1714121bdc571da345540efa05',
+                min_block_number=630000,
+                max_block_number="invalid"
+            )
+
+    @patch.dict(os.environ, {"DERISK_API_URL": DERISK_API_URL})
+    @patch('requests.get')
+    def test_get_data_failure_invalid_from_address(self, mock_get):
+        """Test that data retrieval fails when from_address is None or an invalid format"""
+        connector = DeRiskAPIConnector()
+
+        with self.assertRaises(TypeError):
+            connector.get_data(
+                from_address=None,
+                min_block_number=630000,
+                max_block_number=631000
+            )
+
+        with self.assertRaises(ValueError):
+            connector.get_data(
+                from_address="invalid_address",
+                min_block_number=630000,
+                max_block_number=631000
+            )


### PR DESCRIPTION
Closes #222 

The new changes implemented in [test_api_connector.py](https://github.com/ooochoche/derisk-research/blob/master/data_handler/tests/test_api_connector.py) implements test for the following
- DeRiskConnector Initializes successfully when the DERISK_API_URL environment variable is provided
- DeRiskConnector throws a ValueError when the DERISK_API_URL environment variable is not provided
- DeRiskConnector gets and returns data successfully
- DeRiskConnector fails to return any data

