### PR TITLE
Enhance `docker-compose.yaml` with PostgreSQL Support and Improved Service Configuration

### DIFF
--- a/apps/sdk/README.md
+++ b/apps/sdk/README.md
@@ -29,7 +29,7 @@ cd sdk
 Create `.env` file or just rename `.env.dev` --> `.env`
 
 ```bash
-mv .env.example .env
+mv .env.dev .env
 ```
 
 4. Provide all environment variables needed

--- a/apps/sdk/README.md
+++ b/apps/sdk/README.md
@@ -11,7 +11,39 @@ This project is a FastAPI-based application, set up with Poetry for dependency m
 
 ### Run the Project
 
-1. **Build and Run the Services**
+1. Clone git repository
+
+```bash
+git clone https://github.com/CarmineOptions/derisk-research.git
+```
+
+2. Go to `data_handler/`
+
+
+```bash
+cd sdk 
+```
+
+3. Configure Environment Variables
+
+Create `.env` file or just rename `.env.dev` --> `.env`
+
+```bash
+mv .env.example .env
+```
+
+4. Provide all environment variables needed
+
+```bash
+# postgresql 
+DB_HOST=
+DB_NAME=
+DB_USER=
+DB_PASSWORD=
+DB_PORT=
+```
+
+5. **Build and Run the Services**
 
    Use `docker-compose` to build and run the project:
 
@@ -23,7 +55,7 @@ This project is a FastAPI-based application, set up with Poetry for dependency m
 
    • The Redis service will run on port 6379.
 
-2. **Stop the Services**
+6. **Stop the Services**
 
    To stop the running containers, use:
 

--- a/apps/sdk/README.md
+++ b/apps/sdk/README.md
@@ -17,7 +17,7 @@ This project is a FastAPI-based application, set up with Poetry for dependency m
 git clone https://github.com/CarmineOptions/derisk-research.git
 ```
 
-2. Go to `data_handler/`
+2. Go to `sdk/`
 
 
 ```bash

--- a/apps/sdk/docker-compose.yaml
+++ b/apps/sdk/docker-compose.yaml
@@ -20,5 +20,29 @@ services:
     volumes:
       - redis_data:/data
 
+  db:
+    image: postgres:16
+    container_name: postgres
+    restart: always
+    environment:
+      POSTGRES_DB: ${DB_NAME}
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - app_network
+    env_file:
+      - .env
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U ${DB_USER}" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
 volumes:
   redis_data:
+  postgres_data:
+
+networks:
+  app_network:


### PR DESCRIPTION


#  Description
This pull request introduces the following updates to the `docker-compose.yaml` file:

## Issue
Closes #403 

## Changes Made:
1. **Added PostgreSQL Database Service:**
   - Introduced a new `db` service using PostgreSQL version 16.
   - Configured environment variables (`DB_NAME`, `DB_USER`, `DB_PASSWORD`) to support secure and flexible setup.
   - Persistent storage enabled via `postgres_data` volume.
   - Included a health check to validate database readiness with `pg_isready`.

2. **Introduced Networking:**
   - Added a dedicated `app_network` to improve service communication and isolation.

## Test Logs:
All services were tested with Docker Compose. Build and startup logs are included below:

```bash
[+] Building 34.1s (14/14) FINISHED                                                                                                                                            docker:default
 => [backend internal] load build definition from Dockerfile                                                                                                                             0.0s
 => => transferring dockerfile: 519B                                                                                                                                                     0.0s
 => [backend internal] load metadata for docker.io/library/python:3.11-slim                                                                                                              2.3s
 => [backend internal] load .dockerignore                                                                                                                                                0.0s
 => => transferring context: 2B                                                                                                                                                          0.0s
 => [backend 1/8] FROM docker.io/library/python:3.11-slim@sha256:6ed5bff4d7d377e2a27d9285553b8c21cfccc4f00881de1b24c9bc8d90016e82                                                        0.0s
 => [backend internal] load build context                                                                                                                                                0.0s
 => => transferring context: 77.38kB                                                                                                                                                     0.0s
 => CACHED [backend 2/8] WORKDIR /app                                                                                                                                                    0.0s
 => CACHED [backend 3/8] RUN apt-get update && apt-get install -y     curl     && apt-get clean     && rm -rf /var/lib/apt/lists/*                                                       0.0s
 => CACHED [backend 4/8] RUN curl -sSL https://install.python-poetry.org/ | POETRY_HOME=/usr/local/ POETRY_VERSION=1.8.3 python3 -                                                       0.0s
 => CACHED [backend 5/8] RUN poetry config virtualenvs.create false                                                                                                                      0.0s
 => [backend 6/8] COPY pyproject.toml poetry.lock ./                                                                                                                                     0.0s
 => [backend 7/8] RUN poetry install --no-root --only main                                                                                                                              30.8s
 => [backend 8/8] COPY . .                                                                                                                                                               0.0s
 => [backend] exporting to image                                                                                                                                                         0.9s
 => => exporting layers                                                                                                                                                                  0.9s
 => => writing image sha256:4e8d222d2b43bd5cbc41e2bd6bb90b5e3d0aea7e6bcdcf54c0c903a2b3f20666                                                                                             0.0s 
 => => naming to docker.io/library/sdk-backend                                                                                                                                           0.0s 
 => [backend] resolving provenance for metadata file                                                                                                                                     0.0s 
[+] Running 8/8
 ✔ backend                     Built                                                                                                                                                     0.0s 
 ✔ Network sdk_app_network     Created                                                                                                                                                   0.1s 
 ✔ Network sdk_default         Created                                                                                                                                                   0.1s 
 ✔ Volume "sdk_postgres_data"  Created                                                                                                                                                   0.0s 
 ✔ Volume "sdk_redis_data"     Created                                                                                                                                                   0.0s 
 ✔ Container sdk-redis-1       Created                                                                                                                                                   0.0s 
 ✔ Container postgres          Created                                                                                                                                                   0.0s 
 ✔ Container sdk-backend-1     Created                                                                                                                                                   0.0s 
Attaching to postgres, backend-1, redis-1
redis-1    | 1:C 26 Jan 2025 18:23:05.955 # WARNING Memory overcommit must be enabled! Without it, a background save or replication may fail under low memory condition. Being disabled, it can also cause failures without low memory condition, see https://github.com/jemalloc/jemalloc/issues/1328. To fix this issue add 'vm.overcommit_memory = 1' to /etc/sysctl.conf and then reboot or run the command 'sysctl vm.overcommit_memory=1' for this to take effect.
redis-1    | 1:C 26 Jan 2025 18:23:05.955 * oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
redis-1    | 1:C 26 Jan 2025 18:23:05.955 * Redis version=7.4.2, bits=64, commit=00000000, modified=0, pid=1, just started
redis-1    | 1:C 26 Jan 2025 18:23:05.955 # Warning: no config file specified, using the default config. In order to specify a config file use redis-server /path/to/redis.conf
redis-1    | 1:M 26 Jan 2025 18:23:05.955 * monotonic clock: POSIX clock_gettime
redis-1    | 1:M 26 Jan 2025 18:23:05.956 * Running mode=standalone, port=6379.
redis-1    | 1:M 26 Jan 2025 18:23:05.957 * Server initialized
redis-1    | 1:M 26 Jan 2025 18:23:05.957 * Ready to accept connections tcp
postgres   | The files belonging to this database system will be owned by user "postgres".
postgres   | This user must also own the server process.
postgres   | 
postgres   | The database cluster will be initialized with locale "en_US.utf8".
postgres   | The default database encoding has accordingly been set to "UTF8".
postgres   | The default text search configuration will be set to "english".
postgres   | 
postgres   | Data page checksums are disabled.
postgres   | 
postgres   | fixing permissions on existing directory /var/lib/postgresql/data ... ok
postgres   | creating subdirectories ... ok
postgres   | selecting dynamic shared memory implementation ... posix
postgres   | selecting default max_connections ... 100
postgres   | selecting default shared_buffers ... 128MB
postgres   | selecting default time zone ... Etc/UTC
postgres   | creating configuration files ... ok
postgres   | running bootstrap script ... ok
backend-1  | INFO:     Will watch for changes in these directories: ['/app']
backend-1  | INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
backend-1  | INFO:     Started reloader process [1] using StatReload
postgres   | performing post-bootstrap initialization ... ok
postgres   | syncing data to disk ... ok
postgres   | 
postgres   | 
postgres   | Success. You can now start the database server using:
postgres   | 
postgres   |     pg_ctl -D /var/lib/postgresql/data -l logfile start
postgres   | 
postgres   | initdb: warning: enabling "trust" authentication for local connections
postgres   | initdb: hint: You can change this by editing pg_hba.conf or using the option -A, or --auth-local and --auth-host, the next time you run initdb.
postgres   | waiting for server to start....2025-01-26 18:23:06.534 UTC [48] LOG:  starting PostgreSQL 16.6 (Debian 16.6-1.pgdg120+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit
postgres   | 2025-01-26 18:23:06.535 UTC [48] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
postgres   | 2025-01-26 18:23:06.540 UTC [51] LOG:  database system was shut down at 2025-01-26 18:23:06 UTC
postgres   | 2025-01-26 18:23:06.545 UTC [48] LOG:  database system is ready to accept connections
postgres   |  done
postgres   | server started
postgres   | CREATE DATABASE
postgres   | 
postgres   | 
postgres   | /usr/local/bin/docker-entrypoint.sh: ignoring /docker-entrypoint-initdb.d/*
postgres   | 
postgres   | waiting for server to shut down....2025-01-26 18:23:06.723 UTC [48] LOG:  received fast shutdown request
postgres   | 2025-01-26 18:23:06.724 UTC [48] LOG:  aborting any active transactions
postgres   | 2025-01-26 18:23:06.727 UTC [48] LOG:  background worker "logical replication launcher" (PID 54) exited with exit code 1
postgres   | 2025-01-26 18:23:06.727 UTC [49] LOG:  shutting down
postgres   | 2025-01-26 18:23:06.728 UTC [49] LOG:  checkpoint starting: shutdown immediate
postgres   | 2025-01-26 18:23:06.765 UTC [49] LOG:  checkpoint complete: wrote 922 buffers (5.6%); 0 WAL file(s) added, 0 removed, 0 recycled; write=0.015 s, sync=0.015 s, total=0.038 s; sync files=301, longest=0.002 s, average=0.001 s; distance=4255 kB, estimate=4255 kB; lsn=0/19120F8, redo lsn=0/19120F8
postgres   | 2025-01-26 18:23:06.769 UTC [48] LOG:  database system is shut down
postgres   |  done
postgres   | server stopped
postgres   | 
postgres   | PostgreSQL init process complete; ready for start up.
postgres   | 
postgres   | 2025-01-26 18:23:06.842 UTC [1] LOG:  starting PostgreSQL 16.6 (Debian 16.6-1.pgdg120+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit
postgres   | 2025-01-26 18:23:06.842 UTC [1] LOG:  listening on IPv4 address "0.0.0.0", port 5432
postgres   | 2025-01-26 18:23:06.842 UTC [1] LOG:  listening on IPv6 address "::", port 5432
postgres   | 2025-01-26 18:23:06.845 UTC [1] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
```
