### PR TITLE
Feature/434 add kstrk token

### DIFF
--- a/apps/dashboard_app/charts/constants.py
+++ b/apps/dashboard_app/charts/constants.py
@@ -9,6 +9,7 @@ SUPPLY_STATS_TOKEN_SYMBOLS_MAPPING = {
     "wsteth": "wstETH",
     "lords": "LORDS",
     "strk": "STRK",
+    "kstrk": "kSTRK",
 }
 
 

--- a/apps/dashboard_app/helpers/protocol_stats.py
+++ b/apps/dashboard_app/helpers/protocol_stats.py
@@ -10,11 +10,18 @@ import numpy as np
 import pandas as pd
 from data_handler.handlers import blockchain_call
 from shared.constants import TOKEN_SETTINGS
-from shared.state import State
 from shared.custom_types import Prices
+from shared.state import State
 
-from dashboard_app.helpers.loans_table import get_protocol, get_supply_function_call_parameters
-from dashboard_app.helpers.tools import add_leading_zeros, get_addresses, get_underlying_address
+from dashboard_app.helpers.loans_table import (
+    get_protocol,
+    get_supply_function_call_parameters,
+)
+from dashboard_app.helpers.tools import (
+    add_leading_zeros,
+    get_addresses,
+    get_underlying_address,
+)
 
 
 def get_general_stats(
@@ -109,6 +116,7 @@ def get_supply_stats(
                 "wstETH supply": token_supplies.get("wstETH", default_value),
                 "LORDS supply": token_supplies.get("LORDS", default_value),
                 "STRK supply": token_supplies.get("STRK", default_value),
+                "kSTRK supply": token_supplies.get("kSTRK", default_value),
             }
         )
     df = pd.DataFrame(data)
@@ -182,6 +190,7 @@ def get_collateral_stats(
                 "wstETH collateral": token_collaterals["wstETH"],
                 "LORDS collateral": token_collaterals["LORDS"],
                 "STRK collateral": token_collaterals["STRK"],
+                "kSTRK collateral": token_collaterals["kSTRK"],
             }
         )
     return pd.DataFrame(data)
@@ -241,6 +250,7 @@ def get_debt_stats(
                 "wstETH debt": token_debts["wstETH"],
                 "LORDS debt": token_debts["LORDS"],
                 "STRK debt": token_debts["STRK"],
+                "kSTRK debt": token_debts["kSTRK"],
             }
         )
     data = pd.DataFrame(data)
@@ -283,7 +293,7 @@ def get_utilization_stats(
     total_utilization = total_utilization.replace([np.inf, -np.inf], 0).fillna(0)
     data["Total utilization"] = total_utilization.round(4)
 
-    tokens = ["eth", "wbtc", "usdc", "dai", "usdt", "wsteth", "lords", "strk"]
+    tokens = ["eth", "wbtc", "usdc", "dai", "usdt", "wsteth", "lords", "strk", "kstrk"]
 
     for token in tokens:
         debt_col = f"{token} debt"

--- a/apps/dashboard_app/helpers/settings.py
+++ b/apps/dashboard_app/helpers/settings.py
@@ -63,6 +63,11 @@ TOKEN_SETTINGS: dict[str, TokenSettings] = {
         decimal_factor=1e18,
         address="0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
     ),
+    "kSTRK": TokenSettings(
+        symbol="kSTRK",
+        decimal_factor=1e18,
+        address="0x045cd05ee2caaac3459b87e5e2480099d201be2f62243f839f00e10dde7f500c",
+    ),
 }
 
 
@@ -98,4 +103,5 @@ UNDERLYING_SYMBOLS_TO_UNDERLYING_ADDRESSES = {
     "USDT": "0x068f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb8",
     "DAI": "0x00da114221cb83fa859dbdb4c44beeaa0bb37c7537ad5ae66fe5e0efd20e6eb3",
     "DAI V2": "0x05574eb6b8789a91466f902c380d978e472db68170ff82a5b650b95a58ddf4ad",
+    "kSTRK": "0x045cd05ee2caaac3459b87e5e2480099d201be2f62243f839f00e10dde7f500c",
 }

--- a/apps/dashboard_app/helpers/tools.py
+++ b/apps/dashboard_app/helpers/tools.py
@@ -11,12 +11,10 @@ import requests
 from data_handler.handlers.loan_states.abstractions import State
 from shared.amms import SwapAmm
 from shared.blockchain_call import func_call
-from shared.custom_types import TokenParameters, Prices
-
+from shared.custom_types import Prices, TokenParameters
 from starknet_py.cairo.felt import decode_shortstring
 
 AMMS = ["10kSwap", "MySwap", "SithSwap", "JediSwap"]
-kSTRK = "0x045cd05ee2caaac3459b87e5e2480099d201be2f62243f839f00e10dde7f500c"
 
 
 def float_range(start: float, stop: float, step: float) -> Iterator[float]:
@@ -97,10 +95,8 @@ def get_prices(token_decimals: dict[str, int]) -> dict[str, float]:
     tokens_info = response.json()
 
     # Create a map of token addresses to token information, applying add_leading_zeros conditionally
-    # TODO: Add kSTRK token later
-    # FIXME: Remove `if` condition once kSTRK token will be added
     token_info_map = {
-        add_leading_zeros(token["address"]): token for token in tokens_info if add_leading_zeros(token["address"]) != kSTRK
+        add_leading_zeros(token["address"]): token for token in tokens_info
     }
 
     prices = {}

--- a/apps/dashboard_app/tests/protocol_stats_test.py
+++ b/apps/dashboard_app/tests/protocol_stats_test.py
@@ -295,7 +295,9 @@ def test_get_utilization_stats():
             "Total supply (USD)": [4000],
             **{
                 f"{token} supply": [
-                    1000 if token in ["USDC", "DAI", "USDT", "LORDS", "STRK"] else 1
+                    1000
+                    if token in ["USDC", "DAI", "USDT", "LORDS", "STRK", "kSTRK"]
+                    else 1
                 ]
                 for token in [
                     "ETH",
@@ -306,6 +308,7 @@ def test_get_utilization_stats():
                     "wstETH",
                     "LORDS",
                     "STRK",
+                    "kSTRK",
                 ]
             },
         }
@@ -316,7 +319,9 @@ def test_get_utilization_stats():
             "Protocol": ["zkLend"],
             **{
                 f"{token} debt": [
-                    500 if token in ["USDC", "DAI", "USDT", "LORDS", "STRK"] else 0.5
+                    500
+                    if token in ["USDC", "DAI", "USDT", "LORDS", "STRK", "kSTRK"]
+                    else 0.5
                 ]
                 for token in [
                     "ETH",
@@ -327,6 +332,7 @@ def test_get_utilization_stats():
                     "wstETH",
                     "LORDS",
                     "STRK",
+                    "kSTRK",
                 ]
             },
         }
@@ -371,6 +377,7 @@ def test_get_utilization_stats_division_by_zero():
                     "wstETH",
                     "LORDS",
                     "STRK",
+                    "kSTRK",
                 ]
             },
         }
@@ -390,6 +397,7 @@ def test_get_utilization_stats_division_by_zero():
                     "wstETH",
                     "LORDS",
                     "STRK",
+                    "kSTRK",
                 ]
             },
         }

--- a/apps/dashboard_app/tests/protocol_stats_test.py
+++ b/apps/dashboard_app/tests/protocol_stats_test.py
@@ -4,17 +4,18 @@ Tests for the protocol_stats module.
 
 from decimal import Decimal
 from unittest.mock import MagicMock, patch
+
 import pandas as pd
 import pytest
+from shared.state import State
 
 from dashboard_app.helpers.protocol_stats import (
-    get_general_stats,
-    get_supply_stats,
     get_collateral_stats,
     get_debt_stats,
+    get_general_stats,
+    get_supply_stats,
     get_utilization_stats,
 )
-from shared.state import State
 
 
 @pytest.fixture
@@ -31,7 +32,8 @@ def token_addresses():
         "USDT": "0x068f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb8",
         "wstETH": "0x042b8f0484674ca266ac5d08e4ac6a3fe65bd3129795def2dca5c34ecc5f96d2",
         "LORDS": "0x0124aeb495b947201f5fac96fd1138e326ad86195b98df6dec9009158a533b49",
-        "STRK": "0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d"
+        "STRK": "0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
+        "kSTRK": "0x045cd05ee2caaac3459b87e5e2480099d201be2f62243f839f00e10dde7f500c",
     }
 
 
@@ -41,11 +43,13 @@ def mock_loan_stats():
     Returns a dictionary of loan stats.
     """
     return {
-        "zkLend": pd.DataFrame({
-            "Debt (USD)": [1000],
-            "Risk-adjusted collateral (USD)": [2000],
-            "Collateral (USD)": [2500],
-        })
+        "zkLend": pd.DataFrame(
+            {
+                "Debt (USD)": [1000],
+                "Risk-adjusted collateral (USD)": [2000],
+                "Collateral (USD)": [2500],
+            }
+        )
     }
 
 
@@ -59,7 +63,7 @@ def mock_state(token_addresses):
     state.PROTOCOL_NAME = "zkLend"
     state.compute_number_of_active_loan_entities.return_value = 10
     state.compute_number_of_active_loan_entities_with_debt.return_value = 5
-  
+
     # Setup loan entity with default values
     loan_entity = MagicMock()
     loan_entity.collateral.values = {addr: "0" for addr in token_addresses.values()}
@@ -67,12 +71,13 @@ def mock_state(token_addresses):
     loan_entity.collateral.values[token_addresses["ETH"]] = "1000000000000000000"
     loan_entity.debt[token_addresses["ETH"]] = "2000000000000000000"
     state.loan_entities = {"user1": loan_entity}
- 
+
     # Setup token parameters
     class TokenParam:
         """
         A class to represent token parameters.
         """
+
         def __init__(self, address, symbol):
             self.address = address
             self.underlying_symbol = symbol
@@ -80,8 +85,7 @@ def mock_state(token_addresses):
             self.decimal_factor = 1e18
 
     token_params = {
-        symbol: TokenParam(addr, symbol) 
-        for symbol, addr in token_addresses.items()
+        symbol: TokenParam(addr, symbol) for symbol, addr in token_addresses.items()
     }
 
     state.token_parameters = MagicMock()
@@ -95,8 +99,7 @@ def mock_state(token_addresses):
     state.interest_rate_models.debt = interest_rates.copy()
 
     with patch(
-        "dashboard_app.helpers.protocol_stats.get_protocol",
-        return_value="zkLend"
+        "dashboard_app.helpers.protocol_stats.get_protocol", return_value="zkLend"
     ):
         yield state
 
@@ -115,6 +118,7 @@ def mock_prices(token_addresses):
         token_addresses["wstETH"]: "2100",
         token_addresses["LORDS"]: "0.5",
         token_addresses["STRK"]: "1.2",
+        token_addresses["kSTRK"]: "1.25",
     }
 
 
@@ -124,10 +128,8 @@ def mock_token_settings(token_addresses):
     Returns a dictionary of token settings.
     """
     return {
-        symbol: MagicMock(
-            decimal_factor=Decimal("1e18"),
-            address=addr
-        ) for symbol, addr in token_addresses.items()
+        symbol: MagicMock(decimal_factor=Decimal("1e18"), address=addr)
+        for symbol, addr in token_addresses.items()
     }
 
 
@@ -137,8 +139,7 @@ def patch_token_settings(mock_token_settings):
     Patches the TOKEN_SETTINGS dictionary.
     """
     with patch(
-        "dashboard_app.helpers.protocol_stats.TOKEN_SETTINGS",
-        mock_token_settings
+        "dashboard_app.helpers.protocol_stats.TOKEN_SETTINGS", mock_token_settings
     ):
         yield
 
@@ -148,7 +149,7 @@ def test_get_general_stats(mock_state, mock_loan_stats):
     Tests the get_general_stats function.
     """
     result = get_general_stats([mock_state], mock_loan_stats)
- 
+
     assert isinstance(result, pd.DataFrame)
     assert "Protocol" in result.columns
     assert result["Number of active users"].iloc[0] == 10
@@ -177,13 +178,13 @@ def test_get_general_stats_invalid_loan_stats(mock_state):
 @patch("dashboard_app.helpers.protocol_stats.get_supply_function_call_parameters")
 @patch("dashboard_app.helpers.protocol_stats.asyncio.run")
 def test_get_supply_stats(
-    mock_run, 
-    mock_get_params, 
-    mock_get_protocol, 
-    mock_state, 
-    mock_prices, 
+    mock_run,
+    mock_get_params,
+    mock_get_protocol,
+    mock_state,
+    mock_prices,
     token_addresses,
-    mock_token_settings
+    mock_token_settings,
 ):
     """
     Tests the get_supply_stats function.
@@ -200,6 +201,7 @@ def test_get_supply_stats(
     assert isinstance(result, pd.DataFrame)
     assert "Protocol" in result.columns
     assert "ETH supply" in result.columns
+    assert "kSTRK supply" in result.columns
 
 
 @patch("dashboard_app.helpers.protocol_stats.get_protocol")
@@ -211,7 +213,7 @@ def test_get_supply_stats_blockchain_error(
     mock_get_protocol,
     mock_state,
     mock_prices,
-    token_addresses
+    token_addresses,
 ):
     """
     Tests the get_supply_stats function with a blockchain error.
@@ -280,32 +282,58 @@ def test_get_utilization_stats():
     """
     Tests the get_utilization_stats function.
     """
-    general_stats = pd.DataFrame({
-        "Protocol": ["zkLend"],
-        "Total debt (USD)": [1000],
-    })
+    general_stats = pd.DataFrame(
+        {
+            "Protocol": ["zkLend"],
+            "Total debt (USD)": [1000],
+        }
+    )
 
-    supply_stats = pd.DataFrame({
-        "Protocol": ["zkLend"],
-        "Total supply (USD)": [4000],
-        **{f"{token} supply": [
-            1000 if token in ["USDC", "DAI", "USDT", "LORDS", "STRK"] else 1
-        ] for token in [
-            "ETH", "WBTC", "USDC", "DAI", "USDT", "wstETH", "LORDS", "STRK"
-        ]}
-    })
+    supply_stats = pd.DataFrame(
+        {
+            "Protocol": ["zkLend"],
+            "Total supply (USD)": [4000],
+            **{
+                f"{token} supply": [
+                    1000 if token in ["USDC", "DAI", "USDT", "LORDS", "STRK"] else 1
+                ]
+                for token in [
+                    "ETH",
+                    "WBTC",
+                    "USDC",
+                    "DAI",
+                    "USDT",
+                    "wstETH",
+                    "LORDS",
+                    "STRK",
+                ]
+            },
+        }
+    )
 
-    debt_stats = pd.DataFrame({
-        "Protocol": ["zkLend"],
-        **{f"{token} debt": [
-            500 if token in ["USDC", "DAI", "USDT", "LORDS", "STRK"] else 0.5
-        ] for token in [
-            "ETH", "WBTC", "USDC", "DAI", "USDT", "wstETH", "LORDS", "STRK"
-        ]}
-    })
+    debt_stats = pd.DataFrame(
+        {
+            "Protocol": ["zkLend"],
+            **{
+                f"{token} debt": [
+                    500 if token in ["USDC", "DAI", "USDT", "LORDS", "STRK"] else 0.5
+                ]
+                for token in [
+                    "ETH",
+                    "WBTC",
+                    "USDC",
+                    "DAI",
+                    "USDT",
+                    "wstETH",
+                    "LORDS",
+                    "STRK",
+                ]
+            },
+        }
+    )
 
     result = get_utilization_stats(general_stats, supply_stats, debt_stats)
- 
+
     utilization_columns = [col for col in result.columns if col != "Protocol"]
     result[utilization_columns] = result[utilization_columns].applymap(
         lambda x: round(x, 4)
@@ -321,28 +349,54 @@ def test_get_utilization_stats_division_by_zero():
     """
     Tests the get_utilization_stats function with a division by zero.
     """
-    general_stats = pd.DataFrame({
-        "Protocol": ["zkLend"],
-        "Total debt (USD)": [1000],
-    })
+    general_stats = pd.DataFrame(
+        {
+            "Protocol": ["zkLend"],
+            "Total debt (USD)": [1000],
+        }
+    )
 
-    supply_stats = pd.DataFrame({
-        "Protocol": ["zkLend"],
-        "Total supply (USD)": [0], 
-        **{f"{token} supply": [0] for token in [
-            "ETH", "WBTC", "USDC", "DAI", "USDT", "wstETH", "LORDS", "STRK"
-        ]}
-    })
+    supply_stats = pd.DataFrame(
+        {
+            "Protocol": ["zkLend"],
+            "Total supply (USD)": [0],
+            **{
+                f"{token} supply": [0]
+                for token in [
+                    "ETH",
+                    "WBTC",
+                    "USDC",
+                    "DAI",
+                    "USDT",
+                    "wstETH",
+                    "LORDS",
+                    "STRK",
+                ]
+            },
+        }
+    )
 
-    debt_stats = pd.DataFrame({
-        "Protocol": ["zkLend"],
-        **{f"{token} debt": [0] for token in [
-            "ETH", "WBTC", "USDC", "DAI", "USDT", "wstETH", "LORDS", "STRK"
-        ]}
-    })
+    debt_stats = pd.DataFrame(
+        {
+            "Protocol": ["zkLend"],
+            **{
+                f"{token} debt": [0]
+                for token in [
+                    "ETH",
+                    "WBTC",
+                    "USDC",
+                    "DAI",
+                    "USDT",
+                    "wstETH",
+                    "LORDS",
+                    "STRK",
+                ]
+            },
+        }
+    )
 
     result = get_utilization_stats(general_stats, supply_stats, debt_stats)
 
     # Check if division by zero results in NaN or infinity
-    assert result["Total utilization"].iloc[0] == 1 
+    assert result["Total utilization"].iloc[0] == 1
     assert result["ETH utilization"].iloc[0] == 0.0

--- a/apps/data_handler/handlers/loan_states/hashtack_v1/events.py
+++ b/apps/data_handler/handlers/loan_states/hashtack_v1/events.py
@@ -8,15 +8,14 @@ import logging
 from typing import Optional
 
 import pandas as pd
+from data_handler.db.crud import InitializerDBConnector
 from data_handler.handlers.helpers import MAX_ROUNDING_ERRORS, get_symbol
 from data_handler.handlers.settings import TokenSettings
-
-from data_handler.db.crud import InitializerDBConnector
 from shared.constants import TOKEN_SETTINGS, ProtocolIDs
+from shared.custom_types import InterestRateModels, Portfolio, TokenValues
 from shared.helpers import add_leading_zeros
 from shared.loan_entity import LoanEntity
 from shared.state import State
-from shared.custom_types import InterestRateModels, Portfolio, TokenValues
 
 logger = logging.getLogger(__name__)
 
@@ -45,13 +44,10 @@ ADDRESSES_TO_TOKENS: dict[str, str] = {
     "0x00f0f5b3eed258344152e1f17baf84a2e1b621cd754b625bec169e8595aea767": "JediSwap: DAI/USDT Pool",
     "0x04d0390b777b424e43839cd1e744799f3de6c176c7e32c1812a41dbd9c19db6a": "JediSwap: ETH/USDC Pool",
     "0x045e7131d776dddc137e30bdd490b431c7144677e97bf9369f629ed8d3fb7dd6": "JediSwap: ETH/USDT Pool",
-    "0x05801bdad32f343035fb242e98d1e9371ae85bc1543962fedea16c59b35bd19b":
-    "JediSwap: USDC/USDT Pool",
+    "0x05801bdad32f343035fb242e98d1e9371ae85bc1543962fedea16c59b35bd19b": "JediSwap: USDC/USDT Pool",
     "0x0260e98362e0949fefff8b4de85367c035e44f734c9f8069b6ce2075ae86b45c": "JediSwap: WBTC/ETH Pool",
-    "0x005a8054e5ca0b277b295a830e53bd71a6a6943b42d0dbb22329437522bc80c8":
-    "JediSwap: WBTC/USDC Pool",
-    "0x044d13ad98a46fd2322ef2637e5e4c292ce8822f47b7cb9a1d581176a801c1a0":
-    "JediSwap: WBTC/USDT Pool",
+    "0x005a8054e5ca0b277b295a830e53bd71a6a6943b42d0dbb22329437522bc80c8": "JediSwap: WBTC/USDC Pool",
+    "0x044d13ad98a46fd2322ef2637e5e4c292ce8822f47b7cb9a1d581176a801c1a0": "JediSwap: WBTC/USDT Pool",
     # MySwap pools.
     "0x07c662b10f409d7a0a69c8da79b397fd91187ca5f6230ed30effef2dceddc5b3": "mySwap: DAI/ETH Pool",
     "0x0611e8f4f3badf1737b9e8f0ca77dd2f6b46a1d33ce4eed951c6b18ac497d505": "mySwap: DAI/USDC Pool",
@@ -74,6 +70,7 @@ class HashstackV1SpecificTokenSettings:
     """
     Token settings specific to Hashstack V1, with neutral collateral and debt factors.
     """
+
     # These are set to neutral values because Hashstack V1 doesn't use collateral factors.
     collateral_factor: decimal.Decimal
     # These are set to neutral values because Hashstack V1 doesn't use debt factors.
@@ -85,226 +82,194 @@ class CustomTokenSettings(HashstackV1SpecificTokenSettings, TokenSettings):
     """
     Custom token settings for Hashstack V1, extending specific and general token settings.
     """
+
     pass
 
 
 HASHSTACK_V1_ADDITIONAL_TOKEN_SETTINGS: dict[str, TokenSettings] = {
-    "JediSwap: DAI/ETH Pool":
-    TokenSettings(
+    "JediSwap: DAI/ETH Pool": TokenSettings(
         symbol="JediSwap: DAI/ETH Pool",
         decimal_factor=decimal.Decimal("1e18"),
         address="0x07e2a13b40fc1119ec55e0bcf9428eedaa581ab3c924561ad4e955f95da63138",
     ),
-    "JediSwap: DAI/USDC Pool":
-    TokenSettings(
+    "JediSwap: DAI/USDC Pool": TokenSettings(
         symbol="JediSwap: DAI/USDC Pool",
         decimal_factor=decimal.Decimal("1e18"),
         address="0x00cfd39f5244f7b617418c018204a8a9f9a7f72e71f0ef38f968eeb2a9ca302b",
     ),
-    "JediSwap: DAI/USDT Pool":
-    TokenSettings(
+    "JediSwap: DAI/USDT Pool": TokenSettings(
         symbol="JediSwap: DAI/USDT Pool",
         decimal_factor=decimal.Decimal("1e18"),
         address="0x00f0f5b3eed258344152e1f17baf84a2e1b621cd754b625bec169e8595aea767",
     ),
-    "JediSwap: ETH/USDC Pool":
-    TokenSettings(
+    "JediSwap: ETH/USDC Pool": TokenSettings(
         symbol="JediSwap: ETH/USDC Pool",
         decimal_factor=decimal.Decimal("1e18"),
         address="0x04d0390b777b424e43839cd1e744799f3de6c176c7e32c1812a41dbd9c19db6a",
     ),
-    "JediSwap: ETH/USDT Pool":
-    TokenSettings(
+    "JediSwap: ETH/USDT Pool": TokenSettings(
         symbol="JediSwap: ETH/USDT Pool",
         decimal_factor=decimal.Decimal("1e18"),
         address="0x045e7131d776dddc137e30bdd490b431c7144677e97bf9369f629ed8d3fb7dd6",
     ),
-    "JediSwap: USDC/USDT Pool":
-    TokenSettings(
+    "JediSwap: USDC/USDT Pool": TokenSettings(
         symbol="JediSwap: USDC/USDT Pool",
         decimal_factor=decimal.Decimal("1e18"),
         address="0x05801bdad32f343035fb242e98d1e9371ae85bc1543962fedea16c59b35bd19b",
     ),
-    "JediSwap: WBTC/ETH Pool":
-    TokenSettings(
+    "JediSwap: WBTC/ETH Pool": TokenSettings(
         symbol="JediSwap: WBTC/ETH Pool",
         decimal_factor=decimal.Decimal("1e18"),
         address="0x0260e98362e0949fefff8b4de85367c035e44f734c9f8069b6ce2075ae86b45c",
     ),
-    "JediSwap: WBTC/USDC Pool":
-    TokenSettings(
+    "JediSwap: WBTC/USDC Pool": TokenSettings(
         symbol="JediSwap: WBTC/USDC Pool",
         decimal_factor=decimal.Decimal("1e18"),
         address="0x005a8054e5ca0b277b295a830e53bd71a6a6943b42d0dbb22329437522bc80c8",
     ),
-    "JediSwap: WBTC/USDT Pool":
-    TokenSettings(
+    "JediSwap: WBTC/USDT Pool": TokenSettings(
         symbol="JediSwap: WBTC/USDT Pool",
         decimal_factor=decimal.Decimal("1e18"),
         address="0x044d13ad98a46fd2322ef2637e5e4c292ce8822f47b7cb9a1d581176a801c1a0",
     ),
-    "mySwap: DAI/ETH Pool":
-    TokenSettings(
+    "mySwap: DAI/ETH Pool": TokenSettings(
         symbol="mySwap: DAI/ETH Pool",
         decimal_factor=decimal.Decimal("1e18"),
         address="0x07c662b10f409d7a0a69c8da79b397fd91187ca5f6230ed30effef2dceddc5b3",
     ),
-    "mySwap: DAI/USDC Pool":
-    TokenSettings(
+    "mySwap: DAI/USDC Pool": TokenSettings(
         symbol="mySwap: DAI/USDC Pool",
         decimal_factor=decimal.Decimal("1e12"),
         address="0x0611e8f4f3badf1737b9e8f0ca77dd2f6b46a1d33ce4eed951c6b18ac497d505",
     ),
-    "mySwap: ETH/USDC Pool":
-    TokenSettings(
+    "mySwap: ETH/USDC Pool": TokenSettings(
         symbol="mySwap: ETH/USDC Pool",
         decimal_factor=decimal.Decimal("1e12"),
         address="0x022b05f9396d2c48183f6deaf138a57522bcc8b35b67dee919f76403d1783136",
     ),
-    "mySwap: ETH/USDT Pool":
-    TokenSettings(
+    "mySwap: ETH/USDT Pool": TokenSettings(
         symbol="mySwap: ETH/USDT Pool",
         decimal_factor=decimal.Decimal("1e12"),
         address="0x041f9a1e9a4d924273f5a5c0c138d52d66d2e6a8bee17412c6b0f48fe059ae04",
     ),
-    "mySwap: USDC/USDT Pool":
-    TokenSettings(
+    "mySwap: USDC/USDT Pool": TokenSettings(
         symbol="mySwap: USDC/USDT Pool",
         decimal_factor=decimal.Decimal("1e6"),
         address="0x01ea237607b7d9d2e9997aa373795929807552503683e35d8739f4dc46652de1",
     ),
-    "mySwap: WBTC/USDC Pool":
-    TokenSettings(
+    "mySwap: WBTC/USDC Pool": TokenSettings(
         symbol="mySwap: WBTC/USDC Pool",
         decimal_factor=decimal.Decimal("1e7"),
         address="0x025b392609604c75d62dde3d6ae98e124a31b49123b8366d7ce0066ccb94f696",
     ),
 }
 HASHSTACK_V1_SPECIFIC_TOKEN_SETTINGS: dict[str, TokenSettings] = {
-    "ETH":
-    HashstackV1SpecificTokenSettings(
+    "ETH": HashstackV1SpecificTokenSettings(
         collateral_factor=decimal.Decimal("1"), debt_factor=decimal.Decimal("1")
     ),
-    "wBTC":
-    HashstackV1SpecificTokenSettings(
+    "wBTC": HashstackV1SpecificTokenSettings(
         collateral_factor=decimal.Decimal("1"), debt_factor=decimal.Decimal("1")
     ),
-    "USDC":
-    HashstackV1SpecificTokenSettings(
+    "USDC": HashstackV1SpecificTokenSettings(
         collateral_factor=decimal.Decimal("1"), debt_factor=decimal.Decimal("1")
     ),
-    "DAI":
-    HashstackV1SpecificTokenSettings(
+    "DAI": HashstackV1SpecificTokenSettings(
         collateral_factor=decimal.Decimal("1"), debt_factor=decimal.Decimal("1")
     ),
-    "USDT":
-    HashstackV1SpecificTokenSettings(
+    "USDT": HashstackV1SpecificTokenSettings(
         collateral_factor=decimal.Decimal("1"), debt_factor=decimal.Decimal("1")
     ),
     # TODO: Add wstETH.
-    "wstETH":
-    HashstackV1SpecificTokenSettings(
+    "wstETH": HashstackV1SpecificTokenSettings(
         collateral_factor=decimal.Decimal("1"),
         debt_factor=decimal.Decimal("1"),
     ),
     # TODO: Add LORDS.
-    "LORDS":
-    HashstackV1SpecificTokenSettings(
+    "LORDS": HashstackV1SpecificTokenSettings(
         collateral_factor=decimal.Decimal("1"),
         debt_factor=decimal.Decimal("1"),
     ),
     # TODO: Add STRK.
-    "STRK":
-    HashstackV1SpecificTokenSettings(
+    "STRK": HashstackV1SpecificTokenSettings(
         collateral_factor=decimal.Decimal("1"),
         debt_factor=decimal.Decimal("1"),
     ),
-    "JediSwap: DAI/ETH Pool":
-    HashstackV1SpecificTokenSettings(
+    "kSTRK": HashstackV1SpecificTokenSettings(
         collateral_factor=decimal.Decimal("1"),
         debt_factor=decimal.Decimal("1"),
     ),
-    "JediSwap: DAI/USDC Pool":
-    HashstackV1SpecificTokenSettings(
+    "JediSwap: DAI/ETH Pool": HashstackV1SpecificTokenSettings(
         collateral_factor=decimal.Decimal("1"),
         debt_factor=decimal.Decimal("1"),
     ),
-    "JediSwap: DAI/USDT Pool":
-    HashstackV1SpecificTokenSettings(
+    "JediSwap: DAI/USDC Pool": HashstackV1SpecificTokenSettings(
         collateral_factor=decimal.Decimal("1"),
         debt_factor=decimal.Decimal("1"),
     ),
-    "JediSwap: ETH/USDC Pool":
-    HashstackV1SpecificTokenSettings(
+    "JediSwap: DAI/USDT Pool": HashstackV1SpecificTokenSettings(
         collateral_factor=decimal.Decimal("1"),
         debt_factor=decimal.Decimal("1"),
     ),
-    "JediSwap: ETH/USDT Pool":
-    HashstackV1SpecificTokenSettings(
+    "JediSwap: ETH/USDC Pool": HashstackV1SpecificTokenSettings(
         collateral_factor=decimal.Decimal("1"),
         debt_factor=decimal.Decimal("1"),
     ),
-    "JediSwap: USDC/USDT Pool":
-    HashstackV1SpecificTokenSettings(
+    "JediSwap: ETH/USDT Pool": HashstackV1SpecificTokenSettings(
         collateral_factor=decimal.Decimal("1"),
         debt_factor=decimal.Decimal("1"),
     ),
-    "JediSwap: WBTC/ETH Pool":
-    HashstackV1SpecificTokenSettings(
+    "JediSwap: USDC/USDT Pool": HashstackV1SpecificTokenSettings(
         collateral_factor=decimal.Decimal("1"),
         debt_factor=decimal.Decimal("1"),
     ),
-    "JediSwap: WBTC/USDC Pool":
-    HashstackV1SpecificTokenSettings(
+    "JediSwap: WBTC/ETH Pool": HashstackV1SpecificTokenSettings(
         collateral_factor=decimal.Decimal("1"),
         debt_factor=decimal.Decimal("1"),
     ),
-    "JediSwap: WBTC/USDT Pool":
-    HashstackV1SpecificTokenSettings(
+    "JediSwap: WBTC/USDC Pool": HashstackV1SpecificTokenSettings(
         collateral_factor=decimal.Decimal("1"),
         debt_factor=decimal.Decimal("1"),
     ),
-    "mySwap: DAI/ETH Pool":
-    HashstackV1SpecificTokenSettings(
+    "JediSwap: WBTC/USDT Pool": HashstackV1SpecificTokenSettings(
         collateral_factor=decimal.Decimal("1"),
         debt_factor=decimal.Decimal("1"),
     ),
-    "mySwap: DAI/USDC Pool":
-    HashstackV1SpecificTokenSettings(
+    "mySwap: DAI/ETH Pool": HashstackV1SpecificTokenSettings(
         collateral_factor=decimal.Decimal("1"),
         debt_factor=decimal.Decimal("1"),
     ),
-    "mySwap: ETH/USDC Pool":
-    HashstackV1SpecificTokenSettings(
+    "mySwap: DAI/USDC Pool": HashstackV1SpecificTokenSettings(
         collateral_factor=decimal.Decimal("1"),
         debt_factor=decimal.Decimal("1"),
     ),
-    "mySwap: ETH/USDT Pool":
-    HashstackV1SpecificTokenSettings(
+    "mySwap: ETH/USDC Pool": HashstackV1SpecificTokenSettings(
         collateral_factor=decimal.Decimal("1"),
         debt_factor=decimal.Decimal("1"),
     ),
-    "mySwap: USDC/USDT Pool":
-    HashstackV1SpecificTokenSettings(
+    "mySwap: ETH/USDT Pool": HashstackV1SpecificTokenSettings(
         collateral_factor=decimal.Decimal("1"),
         debt_factor=decimal.Decimal("1"),
     ),
-    "mySwap: WBTC/USDC Pool":
-    HashstackV1SpecificTokenSettings(
+    "mySwap: USDC/USDT Pool": HashstackV1SpecificTokenSettings(
+        collateral_factor=decimal.Decimal("1"),
+        debt_factor=decimal.Decimal("1"),
+    ),
+    "mySwap: WBTC/USDC Pool": HashstackV1SpecificTokenSettings(
         collateral_factor=decimal.Decimal("1"),
         debt_factor=decimal.Decimal("1"),
     ),
 }
 TOKEN_SETTINGS: dict[str, CustomTokenSettings] = {
-    token:
-    CustomTokenSettings(
+    token: CustomTokenSettings(
         symbol=token_settings.symbol,
         decimal_factor=token_settings.decimal_factor,
         address=token_settings.address,
         collateral_factor=HASHSTACK_V1_SPECIFIC_TOKEN_SETTINGS[token].collateral_factor,
         debt_factor=HASHSTACK_V1_SPECIFIC_TOKEN_SETTINGS[token].debt_factor,
     )
-    for token, token_settings in (TOKEN_SETTINGS | HASHSTACK_V1_ADDITIONAL_TOKEN_SETTINGS).items()
+    for token, token_settings in (
+        TOKEN_SETTINGS | HASHSTACK_V1_ADDITIONAL_TOKEN_SETTINGS
+    ).items()
 }
 
 # Keys are values of the "key_name" column in the database, values are the respective method names.
@@ -321,8 +286,10 @@ EVENTS_METHODS_MAPPING: dict[str, str] = {
 MAX_ROUNDING_ERRORS: TokenValues = MAX_ROUNDING_ERRORS
 # TODO: The additional tokens are not allowed in `TokenValues`, fix this.
 MAX_ROUNDING_ERRORS.values.update(
-    {token: decimal.Decimal("0.5e13")
-     for token in HASHSTACK_V1_ADDITIONAL_TOKEN_SETTINGS}
+    {
+        token: decimal.Decimal("0.5e13")
+        for token in HASHSTACK_V1_ADDITIONAL_TOKEN_SETTINGS
+    }
 )
 
 
@@ -334,8 +301,10 @@ class HashstackV1Portfolio(Portfolio):
     def __init__(self) -> None:
         super().__init__()
         self.values.update(
-            {token: decimal.Decimal("0")
-             for token in HASHSTACK_V1_ADDITIONAL_TOKEN_SETTINGS}
+            {
+                token: decimal.Decimal("0")
+                for token in HASHSTACK_V1_ADDITIONAL_TOKEN_SETTINGS
+            }
         )
 
 
@@ -348,8 +317,10 @@ class HashstackV1InterestRateModels(TokenValues):
     def __init__(self) -> None:
         super().__init__(init_value=decimal.Decimal("1"))
         self.values.update(
-            {token: decimal.Decimal("1")
-             for token in HASHSTACK_V1_ADDITIONAL_TOKEN_SETTINGS}
+            {
+                token: decimal.Decimal("1")
+                for token in HASHSTACK_V1_ADDITIONAL_TOKEN_SETTINGS
+            }
         )
 
 
@@ -525,28 +496,38 @@ class HashstackV1State(State):
         debt_token = self.ADDRESSES_TO_TOKENS[add_leading_zeros(event["data"][2])]
         debt_face_amount = decimal.Decimal(str(int(event["data"][3], base=16)))
         borrowed_collateral_token = get_symbol(add_leading_zeros(event["data"][5]))
-        borrowed_collateral_face_amount = decimal.Decimal(str(int(event["data"][6], base=16)))
-        original_collateral_token = self.ADDRESSES_TO_TOKENS[add_leading_zeros(event["data"][13])]
-        original_collateral_face_amount = decimal.Decimal(str(int(event["data"][14], base=16)))
+        borrowed_collateral_face_amount = decimal.Decimal(
+            str(int(event["data"][6], base=16))
+        )
+        original_collateral_token = self.ADDRESSES_TO_TOKENS[
+            add_leading_zeros(event["data"][13])
+        ]
+        original_collateral_face_amount = decimal.Decimal(
+            str(int(event["data"][14], base=16))
+        )
 
         self.loan_entities[loan_id] = HashstackV1LoanEntity(user=user)
         # TODO: Make it possible to initialize `HashstackV1Portfolio`` with some
         # token amount directly.
         original_collateral = HashstackV1Portfolio()
-        original_collateral.values[original_collateral_token] = (original_collateral_face_amount)
+        original_collateral.values[
+            original_collateral_token
+        ] = original_collateral_face_amount
         self.loan_entities[loan_id].original_collateral = original_collateral
         # add additional info block and timestamp
         self.loan_entities[loan_id].extra_info.block = event["block_number"]
         self.loan_entities[loan_id].extra_info.timestamp = event["timestamp"]
 
         borrowed_collateral = HashstackV1Portfolio()
-        borrowed_collateral.values[borrowed_collateral_token] = (borrowed_collateral_face_amount)
+        borrowed_collateral.values[
+            borrowed_collateral_token
+        ] = borrowed_collateral_face_amount
         self.loan_entities[loan_id].borrowed_collateral = borrowed_collateral
         # TODO: Make it easier to sum 2 `HashstackV1Portfolio` instances.
         self.loan_entities[loan_id].collateral.values = {
             token: (
-                self.loan_entities[loan_id].original_collateral.values[token] +
-                self.loan_entities[loan_id].borrowed_collateral.values[token]
+                self.loan_entities[loan_id].original_collateral.values[token]
+                + self.loan_entities[loan_id].borrowed_collateral.values[token]
             )
             for token in TOKEN_SETTINGS
         }
@@ -569,8 +550,7 @@ class HashstackV1State(State):
         if self.loan_entities[loan_id].user == self.verbose_user:
             logging.info(
                 "In block number = {}, face amount = {} of token = {} was borrowed against original collateral face "
-                "amount = {} of token = {} and borrowed collateral face amount = {} of token = {}.".
-                format(
+                "amount = {} of token = {} and borrowed collateral face amount = {} of token = {}.".format(
                     event["block_number"],
                     debt_face_amount,
                     debt_token,
@@ -592,16 +572,22 @@ class HashstackV1State(State):
         # https://starkscan.co/event/0x027b7e40273848af37e092eaec38311ac1d2e6c3fc2724020736e9f322b6fcf7_0.
         loan_id = int(event["data"][0], base=16)
 
-        original_collateral_token = self.ADDRESSES_TO_TOKENS[add_leading_zeros(event["data"][1])]
-        original_collateral_face_amount = decimal.Decimal(str(int(event["data"][2], base=16)))
+        original_collateral_token = self.ADDRESSES_TO_TOKENS[
+            add_leading_zeros(event["data"][1])
+        ]
+        original_collateral_face_amount = decimal.Decimal(
+            str(int(event["data"][2], base=16))
+        )
 
         original_collateral = HashstackV1Portfolio()
-        original_collateral.values[original_collateral_token] = (original_collateral_face_amount)
+        original_collateral.values[
+            original_collateral_token
+        ] = original_collateral_face_amount
         self.loan_entities[loan_id].original_collateral = original_collateral
         self.loan_entities[loan_id].collateral.values = {
             token: (
-                self.loan_entities[loan_id].original_collateral.values[token] +
-                self.loan_entities[loan_id].borrowed_collateral.values[token]
+                self.loan_entities[loan_id].original_collateral.values[token]
+                + self.loan_entities[loan_id].borrowed_collateral.values[token]
             )
             for token in TOKEN_SETTINGS
         }
@@ -637,20 +623,22 @@ class HashstackV1State(State):
 
         new_debt_token = self.ADDRESSES_TO_TOKENS[add_leading_zeros(event["data"][14])]
         new_debt_face_amount = decimal.Decimal(str(int(event["data"][15], base=16)))
-        new_borrowed_collateral_token = self.ADDRESSES_TO_TOKENS[add_leading_zeros(
-            event["data"][17]
-        )]
-        new_borrowed_collateral_face_amount = decimal.Decimal(str(int(event["data"][18], base=16)))
+        new_borrowed_collateral_token = self.ADDRESSES_TO_TOKENS[
+            add_leading_zeros(event["data"][17])
+        ]
+        new_borrowed_collateral_face_amount = decimal.Decimal(
+            str(int(event["data"][18], base=16))
+        )
 
         new_borrowed_collateral = HashstackV1Portfolio()
-        new_borrowed_collateral.values[new_borrowed_collateral_token] = (
-            new_borrowed_collateral_face_amount
-        )
+        new_borrowed_collateral.values[
+            new_borrowed_collateral_token
+        ] = new_borrowed_collateral_face_amount
         self.loan_entities[new_loan_id].borrowed_collateral = new_borrowed_collateral
         self.loan_entities[new_loan_id].collateral.values = {
             token: (
-                self.loan_entities[new_loan_id].original_collateral.values[token] +
-                self.loan_entities[new_loan_id].borrowed_collateral.values[token]
+                self.loan_entities[new_loan_id].original_collateral.values[token]
+                + self.loan_entities[new_loan_id].borrowed_collateral.values[token]
             )
             for token in TOKEN_SETTINGS
         }
@@ -727,27 +715,31 @@ class HashstackV1State(State):
 
         new_debt_token = self.ADDRESSES_TO_TOKENS[add_leading_zeros(event["data"][14])]
         new_debt_face_amount = decimal.Decimal(str(int(event["data"][15], base=16)))
-        new_borrowed_collateral_token = self.ADDRESSES_TO_TOKENS[add_leading_zeros(
-            event["data"][17]
-        )]
-        new_borrowed_collateral_face_amount = decimal.Decimal(str(int(event["data"][18], base=16)))
-        new_original_collateral_token = self.ADDRESSES_TO_TOKENS[add_leading_zeros(
-            event["data"][25]
-        )]
-        new_original_collateral_face_amount = decimal.Decimal(str(int(event["data"][26], base=16)))
+        new_borrowed_collateral_token = self.ADDRESSES_TO_TOKENS[
+            add_leading_zeros(event["data"][17])
+        ]
+        new_borrowed_collateral_face_amount = decimal.Decimal(
+            str(int(event["data"][18], base=16))
+        )
+        new_original_collateral_token = self.ADDRESSES_TO_TOKENS[
+            add_leading_zeros(event["data"][25])
+        ]
+        new_original_collateral_face_amount = decimal.Decimal(
+            str(int(event["data"][26], base=16))
+        )
         # Based on the documentation, it seems that it's only possible to repay the whole amount.
         assert new_debt_face_amount == decimal.Decimal("0")
         assert new_borrowed_collateral_face_amount == decimal.Decimal("0")
         assert new_original_collateral_face_amount == decimal.Decimal("0")
 
         new_original_collateral = HashstackV1Portfolio()
-        new_original_collateral.values[new_original_collateral_token] = (
-            new_original_collateral_face_amount
-        )
+        new_original_collateral.values[
+            new_original_collateral_token
+        ] = new_original_collateral_face_amount
         new_borrowed_collateral = HashstackV1Portfolio()
-        new_borrowed_collateral.values[new_borrowed_collateral_token] = (
-            new_borrowed_collateral_face_amount
-        )
+        new_borrowed_collateral.values[
+            new_borrowed_collateral_token
+        ] = new_borrowed_collateral_face_amount
         self.loan_entities[new_loan_id].original_collateral = new_original_collateral
         self.loan_entities[new_loan_id].borrowed_collateral = new_borrowed_collateral
         # add additional info block and timestamp
@@ -756,8 +748,8 @@ class HashstackV1State(State):
 
         self.loan_entities[new_loan_id].collateral.values = {
             token: (
-                self.loan_entities[new_loan_id].original_collateral.values[token] +
-                self.loan_entities[new_loan_id].borrowed_collateral.values[token]
+                self.loan_entities[new_loan_id].original_collateral.values[token]
+                + self.loan_entities[new_loan_id].borrowed_collateral.values[token]
             )
             for token in TOKEN_SETTINGS
         }
@@ -820,7 +812,9 @@ class HashstackV1State(State):
                 continue
 
             # Find out how much of the `debt_token` will be liquidated.
-            max_liquidated_amount += loan_entity.compute_debt_to_be_liquidated(debt_usd=debt_usd)
+            max_liquidated_amount += loan_entity.compute_debt_to_be_liquidated(
+                debt_usd=debt_usd
+            )
         return max_liquidated_amount
 
     def compute_number_of_active_users(self) -> int:
@@ -840,6 +834,7 @@ class HashstackV1State(State):
         """
         unique_active_borrowers = {
             loan_entity.user
-            for loan_entity in self.loan_entities.values() if loan_entity.has_debt()
+            for loan_entity in self.loan_entities.values()
+            if loan_entity.has_debt()
         }
         return len(unique_active_borrowers)

--- a/apps/data_handler/handlers/loan_states/zklend/settings.py
+++ b/apps/data_handler/handlers/loan_states/zklend/settings.py
@@ -9,6 +9,7 @@ from shared.custom_types import TokenSettings
 @dataclass
 class ZkLendSpecificTokenSettings:
     """Class for ZkLend specific token settings."""
+
     # Source: https://zklend.gitbook.io/documentation/using-zklend/technical/asset-parameters.
     collateral_factor: decimal.Decimal
     # These are set to neutral values because zkLend doesn't use debt factors.
@@ -21,80 +22,80 @@ class ZkLendSpecificTokenSettings:
 @dataclass
 class TokenSettings(ZkLendSpecificTokenSettings, TokenSettings):
     """Class for token settings."""
+
     pass
 
 
 ZKLEND_SPECIFIC_TOKEN_SETTINGS: dict[str, ZkLendSpecificTokenSettings] = {
-    "ETH":
-    ZkLendSpecificTokenSettings(
+    "ETH": ZkLendSpecificTokenSettings(
         collateral_factor=decimal.Decimal("0.80"),
         debt_factor=decimal.Decimal("1"),
         liquidation_bonus=decimal.Decimal("0.10"),
         protocol_token_address="0x01b5bd713e72fdc5d63ffd83762f81297f6175a5e0a4771cdadbc1dd5fe72cb1",
     ),
-    "wBTC":
-    ZkLendSpecificTokenSettings(
+    "wBTC": ZkLendSpecificTokenSettings(
         collateral_factor=decimal.Decimal("0.70"),
         debt_factor=decimal.Decimal("1"),
         liquidation_bonus=decimal.Decimal("0.15"),
         protocol_token_address="0x02b9ea3acdb23da566cee8e8beae3125a1458e720dea68c4a9a7a2d8eb5bbb4a",
     ),
-    "USDC":
-    ZkLendSpecificTokenSettings(
+    "USDC": ZkLendSpecificTokenSettings(
         collateral_factor=decimal.Decimal("0.80"),
         debt_factor=decimal.Decimal("1"),
         liquidation_bonus=decimal.Decimal("0.10"),
         protocol_token_address="0x047ad51726d891f972e74e4ad858a261b43869f7126ce7436ee0b2529a98f486",
     ),
-    "DAI":
-    ZkLendSpecificTokenSettings(
+    "DAI": ZkLendSpecificTokenSettings(
         collateral_factor=decimal.Decimal("0.70"),
         debt_factor=decimal.Decimal("1"),
         liquidation_bonus=decimal.Decimal("0.10"),
         protocol_token_address="0x062fa7afe1ca2992f8d8015385a279f49fad36299754fb1e9866f4f052289376",
     ),
-    "USDT":
-    ZkLendSpecificTokenSettings(
+    "USDT": ZkLendSpecificTokenSettings(
         collateral_factor=decimal.Decimal("0.80"),
         debt_factor=decimal.Decimal("1"),
         liquidation_bonus=decimal.Decimal("0.10"),
         protocol_token_address="0x00811d8da5dc8a2206ea7fd0b28627c2d77280a515126e62baa4d78e22714c4a",
     ),
-    "wstETH":
-    ZkLendSpecificTokenSettings(
+    "wstETH": ZkLendSpecificTokenSettings(
         collateral_factor=decimal.Decimal("0.80"),
         debt_factor=decimal.Decimal("1"),
         liquidation_bonus=decimal.Decimal("0.10"),
         protocol_token_address="0x0536aa7e01ecc0235ca3e29da7b5ad5b12cb881e29034d87a4290edbb20b7c28",
     ),
     # TODO: Add LORDS.
-    "LORDS":
-    ZkLendSpecificTokenSettings(
+    "LORDS": ZkLendSpecificTokenSettings(
         collateral_factor=decimal.Decimal("1"),
         debt_factor=decimal.Decimal("1"),
         liquidation_bonus=decimal.Decimal("0"),
         protocol_token_address="",
     ),
     # TODO: Update STRK settings.
-    "STRK":
-    ZkLendSpecificTokenSettings(
+    "STRK": ZkLendSpecificTokenSettings(
         collateral_factor=decimal.Decimal("0.50"),
         debt_factor=decimal.Decimal("1"),
         liquidation_bonus=decimal.Decimal("0.15"),
         protocol_token_address="0x06d8fa671ef84f791b7f601fa79fea8f6ceb70b5fa84189e3159d532162efc21",
     ),
+    "kSTRK": ZkLendSpecificTokenSettings(
+        collateral_factor=decimal.Decimal("0.60"),
+        debt_factor=decimal.Decimal("0.85"),
+        liquidation_bonus=decimal.Decimal("0.15"),
+        protocol_token_address="0x045cd05ee2caaac3459b87e5e2480099d201be2f62243f839f00e10dde7f500c",
+    ),
 }
 
 TOKEN_SETTINGS: dict[str, TokenSettings] = {
-    token:
-    TokenSettings(
+    token: TokenSettings(
         symbol=TOKEN_SETTINGS[token].symbol,
         decimal_factor=TOKEN_SETTINGS[token].decimal_factor,
         address=TOKEN_SETTINGS[token].address,
         collateral_factor=ZKLEND_SPECIFIC_TOKEN_SETTINGS[token].collateral_factor,
         debt_factor=ZKLEND_SPECIFIC_TOKEN_SETTINGS[token].debt_factor,
         liquidation_bonus=ZKLEND_SPECIFIC_TOKEN_SETTINGS[token].liquidation_bonus,
-        protocol_token_address=ZKLEND_SPECIFIC_TOKEN_SETTINGS[token].protocol_token_address,
+        protocol_token_address=ZKLEND_SPECIFIC_TOKEN_SETTINGS[
+            token
+        ].protocol_token_address,
     )
     for token in TOKEN_SETTINGS
 }

--- a/apps/data_handler/handlers/state.py
+++ b/apps/data_handler/handlers/state.py
@@ -11,9 +11,10 @@ from shared.custom_types import TokenSettings
 @dataclasses.dataclass
 class NostraAlphaSpecificTokenSettings(TokenSettings):
     """
-    Settings for a Nostra Alpha token, including collateral and debt factors, 
+    Settings for a Nostra Alpha token, including collateral and debt factors,
     liquidation fees, protocol fee, and token address.
     """
+
     # TODO: Load these via chain calls?
     # Source: Starkscan, e.g.
     # https://starkscan.co/call/0x06f619127a63ddb5328807e535e56baa1e244c8923a3b50c123d41dcbed315da_1_1
@@ -29,8 +30,7 @@ class NostraAlphaSpecificTokenSettings(TokenSettings):
 
 
 NOSTRA_ALPHA_SPECIFIC_TOKEN_SETTINGS: dict[str, NostraAlphaSpecificTokenSettings] = {
-    "ETH":
-    NostraAlphaSpecificTokenSettings(
+    "ETH": NostraAlphaSpecificTokenSettings(
         symbol="ETH",
         decimal_factor=decimal.Decimal("1e18"),
         address="0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
@@ -41,8 +41,7 @@ NOSTRA_ALPHA_SPECIFIC_TOKEN_SETTINGS: dict[str, NostraAlphaSpecificTokenSettings
         protocol_fee=decimal.Decimal("0.02"),
         protocol_token_address="0x04f89253e37ca0ab7190b2e9565808f105585c9cacca6b2fa6145553fa061a41",
     ),
-    "wBTC":
-    NostraAlphaSpecificTokenSettings(
+    "wBTC": NostraAlphaSpecificTokenSettings(
         symbol="wBTC",
         decimal_factor=decimal.Decimal("1e8"),
         address="0x03fe2b97c1fd336e750087d68b9b867997fd64a2661ff3ca5a7c771641e8e7ac",
@@ -53,8 +52,7 @@ NOSTRA_ALPHA_SPECIFIC_TOKEN_SETTINGS: dict[str, NostraAlphaSpecificTokenSettings
         protocol_fee=decimal.Decimal("0.02"),
         protocol_token_address="0x07788bc687f203b6451f2a82e842b27f39c7cae697dace12edfb86c9b1c12f3d",
     ),
-    "USDC":
-    NostraAlphaSpecificTokenSettings(
+    "USDC": NostraAlphaSpecificTokenSettings(
         symbol="USDC",
         decimal_factor=decimal.Decimal("1e6"),
         address="0x053c91253bc9682c04929ca02ed00b3e423f6710d2ee7e0d5ebb06f3ecf368a8",
@@ -65,8 +63,7 @@ NOSTRA_ALPHA_SPECIFIC_TOKEN_SETTINGS: dict[str, NostraAlphaSpecificTokenSettings
         protocol_fee=decimal.Decimal("0.02"),
         protocol_token_address="0x05327df4c669cb9be5c1e2cf79e121edef43c1416fac884559cd94fcb7e6e232",
     ),
-    "DAI":
-    NostraAlphaSpecificTokenSettings(
+    "DAI": NostraAlphaSpecificTokenSettings(
         symbol="DAI",
         decimal_factor=decimal.Decimal("1e18"),
         address="0x00da114221cb83fa859dbdb4c44beeaa0bb37c7537ad5ae66fe5e0efd20e6eb3",
@@ -77,8 +74,7 @@ NOSTRA_ALPHA_SPECIFIC_TOKEN_SETTINGS: dict[str, NostraAlphaSpecificTokenSettings
         protocol_fee=decimal.Decimal("0.02"),
         protocol_token_address="0x02ea39ba7a05f0c936b7468d8bc8d0e1f2116916064e7e163e7c1044d95bd135",
     ),
-    "USDT":
-    NostraAlphaSpecificTokenSettings(
+    "USDT": NostraAlphaSpecificTokenSettings(
         symbol="USDT",
         decimal_factor=decimal.Decimal("1e6"),
         address="0x068f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb8",
@@ -90,8 +86,7 @@ NOSTRA_ALPHA_SPECIFIC_TOKEN_SETTINGS: dict[str, NostraAlphaSpecificTokenSettings
         protocol_token_address="0x040375d0720245bc0d123aa35dc1c93d14a78f64456eff75f63757d99a0e6a83",
     ),
     # TODO: These (`wstETH`,  `LORDS`, and `STRK`) are actually Nostra Mainnet tokens.
-    "wstETH":
-    NostraAlphaSpecificTokenSettings(
+    "wstETH": NostraAlphaSpecificTokenSettings(
         symbol="wstETH",
         decimal_factor=decimal.Decimal("1e18"),
         address="0x042b8f0484674ca266ac5d08e4ac6a3fe65bd3129795def2dca5c34ecc5f96d2",
@@ -102,8 +97,7 @@ NOSTRA_ALPHA_SPECIFIC_TOKEN_SETTINGS: dict[str, NostraAlphaSpecificTokenSettings
         protocol_fee=decimal.Decimal("0.02"),
         protocol_token_address="",
     ),
-    "LORDS":
-    NostraAlphaSpecificTokenSettings(
+    "LORDS": NostraAlphaSpecificTokenSettings(
         symbol="LORDS",
         decimal_factor=decimal.Decimal("1e18"),
         address="0x0124aeb495b947201f5fac96fd1138e326ad86195b98df6dec9009158a533b49",
@@ -114,8 +108,7 @@ NOSTRA_ALPHA_SPECIFIC_TOKEN_SETTINGS: dict[str, NostraAlphaSpecificTokenSettings
         protocol_fee=decimal.Decimal("0"),  # TODO: Not observed yet.
         protocol_token_address="",
     ),
-    "STRK":
-    NostraAlphaSpecificTokenSettings(
+    "STRK": NostraAlphaSpecificTokenSettings(
         symbol="STRK",
         decimal_factor=decimal.Decimal("1e18"),
         address="0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
@@ -134,6 +127,7 @@ class SpecificTokenSettings:
     """
     Basic token settings with collateral and debt factors.
     """
+
     collateral_factor: decimal.Decimal
     debt_factor: decimal.Decimal
 
@@ -143,30 +137,41 @@ class TokenSettings(SpecificTokenSettings, TokenSettings):
     """
     Extends SpecificTokenSettings to include additional token attributes.
     """
+
     pass
 
 
 LOAN_ENTITY_SPECIFIC_TOKEN_SETTINGS: dict[str, SpecificTokenSettings] = {
-    "ETH":
-    SpecificTokenSettings(collateral_factor=decimal.Decimal("1"), debt_factor=decimal.Decimal("1")),
-    "wBTC":
-    SpecificTokenSettings(collateral_factor=decimal.Decimal("1"), debt_factor=decimal.Decimal("1")),
-    "USDC":
-    SpecificTokenSettings(collateral_factor=decimal.Decimal("1"), debt_factor=decimal.Decimal("1")),
-    "DAI":
-    SpecificTokenSettings(collateral_factor=decimal.Decimal("1"), debt_factor=decimal.Decimal("1")),
-    "USDT":
-    SpecificTokenSettings(collateral_factor=decimal.Decimal("1"), debt_factor=decimal.Decimal("1")),
-    "wstETH":
-    SpecificTokenSettings(collateral_factor=decimal.Decimal("1"), debt_factor=decimal.Decimal("1")),
-    "LORDS":
-    SpecificTokenSettings(collateral_factor=decimal.Decimal("1"), debt_factor=decimal.Decimal("1")),
-    "STRK":
-    SpecificTokenSettings(collateral_factor=decimal.Decimal("1"), debt_factor=decimal.Decimal("1")),
+    "ETH": SpecificTokenSettings(
+        collateral_factor=decimal.Decimal("1"), debt_factor=decimal.Decimal("1")
+    ),
+    "wBTC": SpecificTokenSettings(
+        collateral_factor=decimal.Decimal("1"), debt_factor=decimal.Decimal("1")
+    ),
+    "USDC": SpecificTokenSettings(
+        collateral_factor=decimal.Decimal("1"), debt_factor=decimal.Decimal("1")
+    ),
+    "DAI": SpecificTokenSettings(
+        collateral_factor=decimal.Decimal("1"), debt_factor=decimal.Decimal("1")
+    ),
+    "USDT": SpecificTokenSettings(
+        collateral_factor=decimal.Decimal("1"), debt_factor=decimal.Decimal("1")
+    ),
+    "wstETH": SpecificTokenSettings(
+        collateral_factor=decimal.Decimal("1"), debt_factor=decimal.Decimal("1")
+    ),
+    "LORDS": SpecificTokenSettings(
+        collateral_factor=decimal.Decimal("1"), debt_factor=decimal.Decimal("1")
+    ),
+    "STRK": SpecificTokenSettings(
+        collateral_factor=decimal.Decimal("1"), debt_factor=decimal.Decimal("1")
+    ),
+    "kSTRK": SpecificTokenSettings(
+        collateral_factor=decimal.Decimal("1"), debt_factor=decimal.Decimal("1")
+    ),
 }
 TOKEN_SETTINGS: dict[str, TokenSettings] = {
-    token:
-    TokenSettings(
+    token: TokenSettings(
         symbol=TOKEN_SETTINGS[token].symbol,
         decimal_factor=TOKEN_SETTINGS[token].decimal_factor,
         address=TOKEN_SETTINGS[token].address,

--- a/apps/shared/constants.py
+++ b/apps/shared/constants.py
@@ -54,6 +54,11 @@ TOKEN_SETTINGS: dict[str, TokenSettings] = {
         decimal_factor=Decimal("1e18"),
         address="0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
     ),
+    "kSTRK": TokenSettings(
+        symbol="kSTRK",
+        decimal_factor=Decimal("1e18"),
+        address="0x045cd05ee2caaac3459b87e5e2480099d201be2f62243f839f00e10dde7f500c",
+    ),
 }
 POOL_MAPPING: dict[str, dict[str, Union[List, str]]] = {
     "ETH_USDC": {
@@ -194,6 +199,7 @@ class ProtocolIDs(Enum):
         :return: list of values
         """
         return [choice.value for choice in cls]
+
 
 # FIXME Uncomment when DAI is added correct address
 PAIRS: list[str] = [


### PR DESCRIPTION
Closes #434 

### Token Addition:
* [`apps/dashboard_app/charts/constants.py`](diffhunk://#diff-72568587fab6eafe11a55d6dbe52145b672b24d6e36927d2b34864a24558bf46R12): Added `kSTRK` to the token constants.
* [`apps/dashboard_app/helpers/settings.py`](diffhunk://#diff-cfc7e536beb3672f1845f51ecddc19234c351b3a8c41d5a2f04cd39b81cdf329R66-R70): Added `kSTRK` settings including symbol, decimal factor, and address. [[1]](diffhunk://#diff-cfc7e536beb3672f1845f51ecddc19234c351b3a8c41d5a2f04cd39b81cdf329R66-R70) [[2]](diffhunk://#diff-cfc7e536beb3672f1845f51ecddc19234c351b3a8c41d5a2f04cd39b81cdf329R106)

### Statistics Updates:
* [`apps/dashboard_app/helpers/protocol_stats.py`](diffhunk://#diff-e767334e7a568a214be4ce54cf7ea54e749dd1ef5546e7d1fcf6c80d044cd159R119): Updated supply, collateral, debt, and utilization statistics functions to include `kSTRK`. [[1]](diffhunk://#diff-e767334e7a568a214be4ce54cf7ea54e749dd1ef5546e7d1fcf6c80d044cd159R119) [[2]](diffhunk://#diff-e767334e7a568a214be4ce54cf7ea54e749dd1ef5546e7d1fcf6c80d044cd159R193) [[3]](diffhunk://#diff-e767334e7a568a214be4ce54cf7ea54e749dd1ef5546e7d1fcf6c80d044cd159R253) [[4]](diffhunk://#diff-e767334e7a568a214be4ce54cf7ea54e749dd1ef5546e7d1fcf6c80d044cd159L286-R296)

### Test Cases:
* [`apps/dashboard_app/tests/protocol_stats_test.py`](diffhunk://#diff-614afb0210dd952ba60f9c2b13f02c8c498e381a02e91dc975a15c24e4559b19L34-R36): Updated test cases to include `kSTRK` in token addresses, mock data, and assertions. [[1]](diffhunk://#diff-614afb0210dd952ba60f9c2b13f02c8c498e381a02e91dc975a15c24e4559b19L34-R36) [[2]](diffhunk://#diff-614afb0210dd952ba60f9c2b13f02c8c498e381a02e91dc975a15c24e4559b19L44-R52) [[3]](diffhunk://#diff-614afb0210dd952ba60f9c2b13f02c8c498e381a02e91dc975a15c24e4559b19R80-R88) [[4]](diffhunk://#diff-614afb0210dd952ba60f9c2b13f02c8c498e381a02e91dc975a15c24e4559b19L98-R102) [[5]](diffhunk://#diff-614afb0210dd952ba60f9c2b13f02c8c498e381a02e91dc975a15c24e4559b19R121) [[6]](diffhunk://#diff-614afb0210dd952ba60f9c2b13f02c8c498e381a02e91dc975a15c24e4559b19L140-R142) [[7]](diffhunk://#diff-614afb0210dd952ba60f9c2b13f02c8c498e381a02e91dc975a15c24e4559b19L186-R187) [[8]](diffhunk://#diff-614afb0210dd952ba60f9c2b13f02c8c498e381a02e91dc975a15c24e4559b19R204) [[9]](diffhunk://#diff-614afb0210dd952ba60f9c2b13f02c8c498e381a02e91dc975a15c24e4559b19L214-R216) [[10]](diffhunk://#diff-614afb0210dd952ba60f9c2b13f02c8c498e381a02e91dc975a15c24e4559b19L283-R339) [[11]](diffhunk://#diff-614afb0210dd952ba60f9c2b13f02c8c498e381a02e91dc975a15c24e4559b19L324-R404)

### Code Clean-up:
* [`apps/dashboard_app/helpers/tools.py`](diffhunk://#diff-d1a735da476e0fe56d68ae7d5cad4ed4910e606f45961c5b1806940894c63cc6L14-L19): Removed outdated comments and added `kSTRK` to token information mapping. [[1]](diffhunk://#diff-d1a735da476e0fe56d68ae7d5cad4ed4910e606f45961c5b1806940894c63cc6L14-L19) [[2]](diffhunk://#diff-d1a735da476e0fe56d68ae7d5cad4ed4910e606f45961c5b1806940894c63cc6L100-R99)
* [`apps/data_handler/handlers/loan_states/hashtack_v0/events.py`](diffhunk://#diff-dc281825f586748b7e56a2cbe78481d6206f01f74b31a6d73e8699a9724876f5L14-L20): Refactored code for better readability and added `kSTRK` to token settings. [[1]](diffhunk://#diff-dc281825f586748b7e56a2cbe78481d6206f01f74b31a6d73e8699a9724876f5L14-L20) [[2]](diffhunk://#diff-dc281825f586748b7e56a2cbe78481d6206f01f74b31a6d73e8699a9724876f5R77-R79) [[3]](diffhunk://#diff-dc281825f586748b7e56a2cbe78481d6206f01f74b31a6d73e8699a9724876f5L154-R163) [[4]](diffhunk://#diff-dc281825f586748b7e56a2cbe78481d6206f01f74b31a6d73e8699a9724876f5L216-R253)