### PR TITLE
[Dashboard] Add test cases for DashboardDataHandler 

### DIFF
--- a/makefile
+++ b/makefile
@@ -12,3 +12,6 @@ test_data_handler:
 
 test_shared:
 	pytest apps/shared
+
+test_dashboard_app:
+	cd apps/dashboard_app && poetry run pytest


### PR DESCRIPTION
Closes #441
The goal is to cover [DashboardDataHandler](https://github.com/CarmineOptions/derisk-research/blob/master/apps/dashboard_app/helpers/load_data.py) with tests.
I ran into problem that existing tests did not work. So started from mock's refactoring:
* [`apps/dashboard_app/tests/test_dashboard_data_handler.py`](diffhunk://#diff-03843c55183dc4a1d76d28d24d7c41bb1046ebb04560618418bdcfe823c5afc4R1-R70): new fixture `mock_zklend_state` added to  `handler` because zklend_state uses DB.

I found the existing tests to be good. However, the `load_data` method relies mainly on the `prices` attribute and the result of the `_get_loan_stat` function. So i modified existing tests to handle new scenarios:

* [`apps/dashboard_app/tests/test_dashboard_data_handler.py`](diffhunk://#diff-03843c55183dc4a1d76d28d24d7c41bb1046ebb04560618418bdcfe823c5afc4L59-R121): included new assertions to `test_load_data_missing_data` and `test_load_data_invalid_prices`  for better test coverage.

Update to `makefile`:

* [`makefile`](diffhunk://#diff-beda42571c095172ab63437d050612a571d0d9ddd3ad4f2aecbce907a9b7e3d0R15-R17):  a new target `test_dashboard_app` to run this tests from the root of the project.