### PR TITLE
Refactor NostraAlpha loan states, fix interest rate indices in NostraDataParser

### DIFF
--- a/apps/data_handler/handler_tools/data_parser/nostra.py
+++ b/apps/data_handler/handler_tools/data_parser/nostra.py
@@ -29,8 +29,8 @@ class NostraDataParser:
         Parses the interest rate model event data into a human-readable format.
         The event data is fetched from on-chain logs and is structured in the following way:
         - event_data[0]: The debt token address (as a hexadecimal string).
-        - event_data[1]: The lending interest rate index (as a hexadecimal in 18 decimal places).
-        - event_data[2]: The borrow interest rate index (as a hexadecimal in 18 decimal places).
+        - event_data[5]: The lending interest rate index (as a hexadecimal in 18 decimal places).
+        - event_data[7]: The borrow interest rate index (as a hexadecimal in 18 decimal places).
         Args:
             event_data (List[Any]): A list containing the raw event data.
                 Expected order: [debt_token, lending_index, _, borrow_index, _]
@@ -39,8 +39,8 @@ class NostraDataParser:
         """
         return InterestRateModelEventData(
             debt_token=event_data[0],
-            lending_index=event_data[1],
-            borrow_index=event_data[2],
+            lending_index=event_data[5],
+            borrow_index=event_data[7],
         )
 
     @classmethod

--- a/apps/data_handler/handler_tools/nostra_alpha_settings.py
+++ b/apps/data_handler/handler_tools/nostra_alpha_settings.py
@@ -15,6 +15,22 @@ NOSTRA_ALPHA_EVENTS_TO_METHODS: dict[tuple[str, str], str] = {
     ): "process_debt_transfer_event",
     ("debt", "Mint"): "process_debt_mint_event",
     ("debt", "Burn"): "process_debt_burn_event",
+    (
+        "interest_bearing_collateral",
+        "Mint",
+    ): "process_interest_bearing_collateral_mint_event",
+    (
+        "interest_bearing_collateral",
+        "Burn",
+    ): "process_interest_bearing_collateral_burn_event",
+    (
+        "non_interest_bearing_collateral",
+        "Mint",
+    ): "process_non_interest_bearing_collateral_mint_event",
+    (
+        "non_interest_bearing_collateral",
+        "Burn",
+    ): "process_non_interest_bearing_collateral_burn_event",
 }
 
 NOSTRA_ALPHA_EVENTS_TO_ORDER: dict[str, str] = {
@@ -71,26 +87,16 @@ NOSTRA_ALPHA_DEFERRED_BATCH_CALL_ADAPTER_ADDRESS: str = (
 
 # Source: https://docs.nostra.finance/lend/deployed-contracts/lend-alpha#asset-contracts.
 NOSTRA_ALPHA_ADDRESSES_TO_EVENTS: dict[str, str] = {
-    "0x0553cea5d1dc0e0157ffcd36a51a0ced717efdadd5ef1b4644352bb45bd35453":
-    "non_interest_bearing_collateral",
-    "0x047e794d7c49c49fd2104a724cfa69a92c5a4b50a5753163802617394e973833":
-    "non_interest_bearing_collateral",
-    "0x003cd2066f3c8b4677741b39db13acebba843bbbaa73d657412102ab4fd98601":
-    "non_interest_bearing_collateral",
-    "0x04403e420521e7a4ca0dc5192af81ca0bb36de343564a9495e11c8d9ba6e9d17":
-    "non_interest_bearing_collateral",
-    "0x06b59e2a746e141f90ec8b6e88e695265567ab3bdcf27059b4a15c89b0b7bd53":
-    "non_interest_bearing_collateral",
-    "0x070f8a4fcd75190661ca09a7300b7c93fab93971b67ea712c664d7948a8a54c6":
-    "interest_bearing_collateral",
-    "0x029959a546dda754dc823a7b8aa65862c5825faeaaf7938741d8ca6bfdc69e4e":
-    "interest_bearing_collateral",
-    "0x055ba2baf189b98c59f6951a584a3a7d7d6ff2c4ef88639794e739557e1876f0":
-    "interest_bearing_collateral",
-    "0x01ac55cabf2b79cf39b17ba0b43540a64205781c4b7850e881014aea6f89be58":
-    "interest_bearing_collateral",
-    "0x00687b5d9e591844169bc6ad7d7256c4867a10cee6599625b9d78ea17a7caef9":
-    "interest_bearing_collateral",
+    "0x0553cea5d1dc0e0157ffcd36a51a0ced717efdadd5ef1b4644352bb45bd35453": "non_interest_bearing_collateral",
+    "0x047e794d7c49c49fd2104a724cfa69a92c5a4b50a5753163802617394e973833": "non_interest_bearing_collateral",
+    "0x003cd2066f3c8b4677741b39db13acebba843bbbaa73d657412102ab4fd98601": "non_interest_bearing_collateral",
+    "0x04403e420521e7a4ca0dc5192af81ca0bb36de343564a9495e11c8d9ba6e9d17": "non_interest_bearing_collateral",
+    "0x06b59e2a746e141f90ec8b6e88e695265567ab3bdcf27059b4a15c89b0b7bd53": "non_interest_bearing_collateral",
+    "0x070f8a4fcd75190661ca09a7300b7c93fab93971b67ea712c664d7948a8a54c6": "interest_bearing_collateral",
+    "0x029959a546dda754dc823a7b8aa65862c5825faeaaf7938741d8ca6bfdc69e4e": "interest_bearing_collateral",
+    "0x055ba2baf189b98c59f6951a584a3a7d7d6ff2c4ef88639794e739557e1876f0": "interest_bearing_collateral",
+    "0x01ac55cabf2b79cf39b17ba0b43540a64205781c4b7850e881014aea6f89be58": "interest_bearing_collateral",
+    "0x00687b5d9e591844169bc6ad7d7256c4867a10cee6599625b9d78ea17a7caef9": "interest_bearing_collateral",
     "0x040b091cb020d91f4a4b34396946b4d4e2a450dbd9410432ebdbfe10e55ee5e5": "debt",
     "0x03b6058a9f6029b519bc72b2cc31bcb93ca704d0ab79fec2ae5d43f79ac07f7a": "debt",
     "0x065c6c7119b738247583286021ea05acc6417aa86d391dcdda21843c1fc6e9c6": "debt",

--- a/apps/data_handler/handlers/loan_states/nostra_alpha/run.py
+++ b/apps/data_handler/handlers/loan_states/nostra_alpha/run.py
@@ -14,7 +14,6 @@ from data_handler.handler_tools.nostra_alpha_settings import (
 )
 from data_handler.handlers.loan_states.abstractions import LoanStateComputationBase
 from data_handler.handlers.loan_states.nostra_alpha.events import NostraAlphaState
-
 from shared.constants import ProtocolIDs
 
 logger = logging.getLogger(__name__)
@@ -39,7 +38,9 @@ class NostraAlphaStateComputation(LoanStateComputationBase):
     EVENTS_METHODS_MAPPING = NOSTRA_ALPHA_EVENTS_TO_METHODS
     ADDRESSES_TO_EVENTS = NOSTRA_ALPHA_ADDRESSES_TO_EVENTS
 
-    def process_interest_rate_event(self, nostra_state: NostraAlphaState, event: pd.Series) -> None:
+    def process_interest_rate_event(
+        self, nostra_state: NostraAlphaState, event: pd.Series
+    ) -> None:
         """
         Processes an interest rate event.
 
@@ -63,11 +64,13 @@ class NostraAlphaStateComputation(LoanStateComputationBase):
         """
         nostra_alpha_state = NostraAlphaState()
 
-        events_with_interest_rate = (list(self.EVENTS_MAPPING.keys()) + self.INTEREST_RATES_KEYS)
+        events_with_interest_rate = (
+            list(self.EVENTS_MAPPING.keys()) + self.INTEREST_RATES_KEYS
+        )
 
         # Init DataFrame
         df = pd.DataFrame(data)
-        df_filtered = df[df["key_name"].isin(events_with_interest_rate)]
+        df_filtered = df[df["key_name"].isin(events_with_interest_rate)].copy()
         # Map 'key_name' to its corresponding order from the dict
         df_filtered["sort_order"] = df_filtered["key_name"].map(
             lambda x: NOSTRA_ALPHA_EVENTS_TO_ORDER.get(x, float("inf"))

--- a/apps/data_handler/handlers/loan_states/nostra_mainnet/run.py
+++ b/apps/data_handler/handlers/loan_states/nostra_mainnet/run.py
@@ -110,47 +110,6 @@ class NostraMainnetStateComputation(LoanStateComputationBase):
         result_df = self.get_result_df(nostra_mainnet_state.loan_entities)
         return result_df
 
-    def get_result_df(self, loan_entities: dict) -> pd.DataFrame:
-        """
-        Creates a DataFrame with the loan state based on the loan entities.
-        :param loan_entities: dictionary of loan entities
-        :return: dataframe with loan state
-        """
-        users = list(loan_entities.keys())
-        entities = [loan_entities[user] for user in users]
-
-        collateral_data = []
-        for loan in entities:
-            try:
-                # Use .items() directly if values is not a dict
-                if isinstance(loan.collateral.values, dict):
-                    items = loan.collateral.values.items()
-                else:
-                    items = loan.collateral.items()
-
-                collateral_dict = {token: float(amount) for token, amount in items}
-                collateral_data.append(collateral_dict)
-            except Exception as e:
-                logger.error(f"Error processing collateral: {e}", exc_info=True)
-                collateral_data.append({})
-
-        result_dict = {
-            "protocol": [self.PROTOCOL_TYPE] * len(users),
-            "user": users,
-            "collateral": collateral_data,
-            "block": [getattr(entity.extra_info, "block", None) for entity in entities],
-            "timestamp": [
-                getattr(entity.extra_info, "timestamp", None) for entity in entities
-            ],
-            "debt": [
-                {token: float(amount) for token, amount in loan.debt.items()}
-                for loan in entities
-            ],
-        }
-
-        result_df = pd.DataFrame(result_dict)
-        return result_df
-
     def run(self) -> None:
         """
         Runs the loan state computation for the specific protocol.

--- a/apps/data_handler/tests/test_nostra_transformer.py
+++ b/apps/data_handler/tests/test_nostra_transformer.py
@@ -145,9 +145,15 @@ def sample_interest_rate_model_event_data() -> Dict[str, Any]:
         "from_address": "0x08c0a5193d58f74fbace4b74dcf65481e734ed1714121bdc571da345540efa05",
         "keys": ["0x33db1d611576200c90997bde1f948502469d333e65e87045c250e6efd2e42c7"],
         "data": [
-            "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd",  # debt_token
-            "0x2386f26fc10000",  # lending_index
-            "0x2386f26fc10000",  # borrow_index
+            "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd",  # debt_token (0)
+            "0x308201d5c5409",  # lending_rate (1)
+            "0x0",  # (2)
+            "0x171019022a4ccb",  # borrow_rate (3)
+            "0x0",  # (4)
+            "0xde7cce9f071c53d",  # lending_index (5)
+            "0x0",  # (6)
+            "0xdfe7cada85cc95e",  # borrow_index (7)
+            "0x0",  # (8)
         ],
         "timestamp": 1712278700,
         "key_name": "InterestRateModel",
@@ -354,8 +360,8 @@ def test_save_interest_rate_model_event(
 
     expected_parsed_data = InterestRateModelEventData(
         debt_token=sample_interest_rate_model_event_data["data"][0],
-        lending_index=sample_interest_rate_model_event_data["data"][1],
-        borrow_index=sample_interest_rate_model_event_data["data"][2],
+        lending_index=sample_interest_rate_model_event_data["data"][5],
+        borrow_index=sample_interest_rate_model_event_data["data"][7],
     )
 
     transformer.fetch_and_transform_events(


### PR DESCRIPTION
Closes #469

### Event Processing and Parsing Updates:
* [`apps/data_handler/handler_tools/data_parser/nostra.py`](diffhunk://#diff-fdbec2993044f56e913fe84633633def7b0dc34f05f9c7400846181364fc8d63L32-R33): Updated the indices for `lending_index` and `borrow_index` in the `parse_interest_rate_model_event` function to correctly reflect the event data structure. [[1]](diffhunk://#diff-fdbec2993044f56e913fe84633633def7b0dc34f05f9c7400846181364fc8d63L32-R33) [[2]](diffhunk://#diff-fdbec2993044f56e913fe84633633def7b0dc34f05f9c7400846181364fc8d63L42-R43)

### Adding New Event Types:
* [`apps/data_handler/handler_tools/nostra_alpha_settings.py`](diffhunk://#diff-6879a44d7ee6c06f4e0f5f5310dcc94375c96a2b879e4333572e1a18037a3273R18-R33): Added new event types for `interest_bearing_collateral` and `non_interest_bearing_collateral` for both mint and burn events. [[1]](diffhunk://#diff-6879a44d7ee6c06f4e0f5f5310dcc94375c96a2b879e4333572e1a18037a3273R18-R33) [[2]](diffhunk://#diff-6879a44d7ee6c06f4e0f5f5310dcc94375c96a2b879e4333572e1a18037a3273L74-R99)

### Refactoring and Code Cleanup:
* [`apps/data_handler/handlers/loan_states/abstractions.py`](diffhunk://#diff-c70692d269b7c2332f75499af137a3e69645d38590841e6522a289f1fabe2b2bL185-R213): Refactored the `get_result_df` method to simplify the processing of loan entities and handle collateral data more robustly.
* [`apps/data_handler/handlers/loan_states/nostra_alpha/events.py`](diffhunk://#diff-e7c2ca3fa751a0adb6396e210a76344fa65d8ff10d221ee5d3aeb7c246485308L19-R36): Various refactoring changes including switching to `get_async_symbol` for asynchronous symbol fetching, and adding helper methods `_is_ignored_user` and `_get_safe_interest_rate` to improve code readability and maintainability. [[1]](diffhunk://#diff-e7c2ca3fa751a0adb6396e210a76344fa65d8ff10d221ee5d3aeb7c246485308L19-R36) [[2]](diffhunk://#diff-e7c2ca3fa751a0adb6396e210a76344fa65d8ff10d221ee5d3aeb7c246485308L236-R272) [[3]](diffhunk://#diff-e7c2ca3fa751a0adb6396e210a76344fa65d8ff10d221ee5d3aeb7c246485308L308-R375) [[4]](diffhunk://#diff-e7c2ca3fa751a0adb6396e210a76344fa65d8ff10d221ee5d3aeb7c246485308L328-R390)