### PR TITLE
Add get_history_by_wallet_id function

### DIFF
--- a/apps/dashboard_app/app/services/fetch_data.py
+++ b/apps/dashboard_app/app/services/fetch_data.py
@@ -238,6 +238,21 @@ async def get_events_by_hash():
     return trade_open, trade_close
 
 
+def filter_wallet_id(events, wallet_id):
+    """Filter the events given a wallet id
+    wallet_id: string
+        The wallet address to filter the events, given as an integer
+    :returns: list
+        A list containing the filtered events.
+    """
+    filtered_events = []
+    for event in events:
+        if event.user_address == wallet_id:
+            filtered_events.append(event)
+
+    return filtered_events
+
+
 async def get_history_by_wallet_id(wallet_id):
     """Filter the events given a wallet id
 
@@ -248,15 +263,7 @@ async def get_history_by_wallet_id(wallet_id):
     """
     trade_open, trade_close = await get_events_by_hash()
     int_wallet_id = int(wallet_id, 16)
-    filtered_trade_open = []
-    filtered_trade_close = []
-    
-    for event in trade_open:
-        if event.user_address == int_wallet_id:
-            filtered_trade_open.append(event)
-
-    for event in trade_close:
-        if event.user_address == int_wallet_id:
-            filtered_trade_close.append(event)
+    filtered_trade_open = filter_wallet_id(trade_open, int_wallet_id)
+    filtered_trade_close = filter_wallet_id(trade_close, int_wallet_id)
 
     return filtered_trade_open, filtered_trade_close

--- a/apps/dashboard_app/app/services/fetch_data.py
+++ b/apps/dashboard_app/app/services/fetch_data.py
@@ -236,3 +236,27 @@ async def get_events_by_hash():
                 trade_close.append(result)
 
     return trade_open, trade_close
+
+
+async def get_history_by_wallet_id(wallet_id):
+    """Filter the events given a wallet id
+
+    wallet_id: string
+        The wallet address to filter the events, MUST be in hexadecimal format
+    :returns: tuple
+        A tuple containing the filtered trade open and trade close events.
+    """
+    trade_open, trade_close = await get_events_by_hash()
+    int_wallet_id = int(wallet_id, 16)
+    filtered_trade_open = []
+    filtered_trade_close = []
+    
+    for event in trade_open:
+        if event.user_address == int_wallet_id:
+            filtered_trade_open.append(event)
+
+    for event in trade_close:
+        if event.user_address == int_wallet_id:
+            filtered_trade_close.append(event)
+
+    return filtered_trade_open, filtered_trade_close

--- a/apps/dashboard_app/app/services/fetch_data.py
+++ b/apps/dashboard_app/app/services/fetch_data.py
@@ -238,22 +238,17 @@ async def get_events_by_hash():
     return trade_open, trade_close
 
 
-def filter_wallet_id(events, wallet_id):
+def filter_wallet_id(events: list, wallet_id: int) -> list:
     """Filter the events given a wallet id
     wallet_id: string
         The wallet address to filter the events, given as an integer
     :returns: list
         A list containing the filtered events.
     """
-    filtered_events = []
-    for event in events:
-        if event.user_address == wallet_id:
-            filtered_events.append(event)
-
-    return filtered_events
+    return [event for event in events if event.user_address == wallet_id]
 
 
-async def get_history_by_wallet_id(wallet_id):
+async def get_history_by_wallet_id(wallet_id: str) -> tuple:
     """Filter the events given a wallet id
 
     wallet_id: string


### PR DESCRIPTION
Closes #562 

This PR does the following:
- Add a function to filter the events from `get_events_by_hash` given a wallet address.

The wallet_id is a string which MUST be in hexadecimal format, it is converted to integer since the `from_address` field in the events is retrieved as an integer. 

Let me know if any more changes are necessary :D