### PR TITLE
Remove duplicates of the Protocol Ids

### DIFF
--- a/apps/dashboard_app/app/models/watcher.py
+++ b/apps/dashboard_app/app/models/watcher.py
@@ -4,15 +4,7 @@ from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy_utils import IPAddressType
 from datetime import datetime
 from sqlalchemy_utils.types.choice import ChoiceType
-from enum import Enum
-
-
-class ProtocolIDs(str, Enum):
-    HASHSTACK = "Hashstack"
-    NOSTRA_ALPHA = "Nostra_alpha"
-    NOSTRA_MAINNET = "Nostra_mainnet"
-    ZKLEND = "zkLend"
-
+from shared.protocol_ids import ProtocolIDs
 
 class NotificationData(Base):
     __tablename__ = "notification"

--- a/apps/dashboard_app/app/utils/values.py
+++ b/apps/dashboard_app/app/utils/values.py
@@ -1,8 +1,8 @@
 import os
 from dataclasses import dataclass
-from enum import Enum
 
 from dotenv import load_dotenv
+from shared.protocol_ids import ProtocolIDs
 
 load_dotenv()
 
@@ -43,12 +43,6 @@ class CreateSubscriptionValues:
         "Creates a new subscription to notifications"
     )
 
-
-class ProtocolIDs(Enum):
-    HASHSTACK = "Hashstack"
-    NOSTRA_ALPHA = "Nostra_alpha"
-    NOSTRA_MAINNET = "Nostra_mainnet"
-    ZKLEND = "zkLend"
 
 
 HEALTH_RATIO_LEVEL_ALERT_VALUE: float = 0.1

--- a/apps/data_handler/db/crud.py
+++ b/apps/data_handler/db/crud.py
@@ -34,7 +34,7 @@ from data_handler.db.models.zklend_events import (
     RepaymentEventModel,
     WithdrawalEventModel,
 )
-from shared.constants import ProtocolIDs
+from shared.protocol_ids import ProtocolIDs
 from sqlalchemy import Subquery, and_, create_engine, desc, func, select
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.exc import SQLAlchemyError

--- a/apps/data_handler/db/models/base.py
+++ b/apps/data_handler/db/models/base.py
@@ -4,7 +4,7 @@ from sqlalchemy import BigInteger, Column, String
 from sqlalchemy.types import JSON
 from sqlalchemy_utils.types.choice import ChoiceType
 from shared.db import Base
-from shared.constants import ProtocolIDs
+from shared.protocol_ids import ProtocolIDs
 
 
 class BaseState(Base):

--- a/apps/data_handler/db/models/event.py
+++ b/apps/data_handler/db/models/event.py
@@ -13,7 +13,7 @@ from sqlalchemy import Column, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from shared.db import Base
-from shared.constants import ProtocolIDs
+from shared.protocol_ids import ProtocolIDs
 
 
 class EventBaseModel(Base):

--- a/apps/data_handler/db/models/liquidable_debt.py
+++ b/apps/data_handler/db/models/liquidable_debt.py
@@ -5,7 +5,7 @@ from sqlalchemy import DECIMAL, BigInteger, Column, String
 from sqlalchemy_utils.types.choice import ChoiceType
 
 from shared.db import Base
-from shared.constants import ProtocolIDs
+from shared.protocol_ids import ProtocolIDs
 
 
 class LiquidableDebt(Base):

--- a/apps/data_handler/handlers/events/nostra/transform_events.py
+++ b/apps/data_handler/handlers/events/nostra/transform_events.py
@@ -22,7 +22,7 @@ from shared.data_parser.serializers import (
     NonInterestBearingCollateralBurnEventData,
     NonInterestBearingCollateralMintEventData,
 )
-from shared.constants import ProtocolIDs
+from shared.protocol_ids import ProtocolIDs
 
 logger = logging.getLogger(__name__)
 

--- a/apps/data_handler/handlers/events/zklend/transform_events.py
+++ b/apps/data_handler/handlers/events/zklend/transform_events.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel
 from shared.db import Base
 from data_handler.handler_tools.api_connector import DeRiskAPIConnector
 from typing import Dict, Any, Tuple, Type, Callable
-from shared.constants import ProtocolIDs
+from shared.protocol_ids import ProtocolIDs
 from shared.data_parser.zklend import ZklendDataParser
 
 from shared.data_parser.serializers import (

--- a/apps/data_handler/handlers/health_ratio_level/nostra_alpha.py
+++ b/apps/data_handler/handlers/health_ratio_level/nostra_alpha.py
@@ -8,7 +8,7 @@ from data_handler.handlers.liquidable_debt.values import (
 from health_ratio_handlers import NostrAlphaHealthRatioHandler
 
 from data_handler.db.models import HealthRatioLevel
-from shared.constants import ProtocolIDs
+from shared.protocol_ids import ProtocolIDs
 
 
 def run():

--- a/apps/data_handler/handlers/health_ratio_level/nostra_mainnet.py
+++ b/apps/data_handler/handlers/health_ratio_level/nostra_mainnet.py
@@ -8,7 +8,7 @@ from data_handler.handlers.liquidable_debt.values import (
 from health_ratio_handlers import NostrMainnetHealthRatioHandler
 
 from data_handler.db.models import HealthRatioLevel
-from shared.constants import ProtocolIDs
+from shared.protocol_ids import ProtocolIDs
 
 
 def run():

--- a/apps/data_handler/handlers/liquidable_debt/debt_handlers.py
+++ b/apps/data_handler/handlers/liquidable_debt/debt_handlers.py
@@ -17,7 +17,7 @@ from data_handler.handlers.settings import TOKEN_PAIRS
 
 from data_handler.db.crud import DBConnector
 from data_handler.db.models import LoanState
-from shared.constants import ProtocolIDs
+from shared.protocol_ids import ProtocolIDs
 from shared.state import LoanEntity, State
 from shared.custom_types import TokenValues
 

--- a/apps/data_handler/handlers/liquidable_debt/protocols/nostra_mainnet.py
+++ b/apps/data_handler/handlers/liquidable_debt/protocols/nostra_mainnet.py
@@ -13,7 +13,7 @@ from shared.state import NostraMainnetState
 from shared.loan_entity import NostraMainnetLoanEntity
 
 from data_handler.db.models import LiquidableDebt
-from shared.constants import ProtocolIDs
+from shared.protocol_ids import ProtocolIDs
 
 
 def run() -> None:

--- a/apps/data_handler/handlers/loan_states/nostra_alpha/run.py
+++ b/apps/data_handler/handlers/loan_states/nostra_alpha/run.py
@@ -15,7 +15,7 @@ from shared.loan_entity.nostra.alpha import (
 )
 from data_handler.handlers.loan_states.abstractions import LoanStateComputationBase
 from shared.state import NostraAlphaState
-from shared.constants import ProtocolIDs
+from shared.protocol_ids import ProtocolIDs
 
 logger = logging.getLogger(__name__)
 NOSTRA_ALPHA_EVENTS_TO_ORDER: dict[str, int] = {

--- a/apps/data_handler/handlers/loan_states/zklend/run.py
+++ b/apps/data_handler/handlers/loan_states/zklend/run.py
@@ -9,7 +9,7 @@ from data_handler.db.crud import InitializerDBConnector
 from data_handler.handlers.loan_states.abstractions import LoanStateComputationBase
 from shared.state import ZkLendState, State
 from data_handler.handlers.loan_states.zklend.utils import ZkLendInitializer
-from shared.constants import ProtocolIDs
+from shared.protocol_ids import ProtocolIDs
 
 logger = logging.getLogger(__name__)
 

--- a/apps/data_handler/main.py
+++ b/apps/data_handler/main.py
@@ -27,7 +27,7 @@ from data_handler.db.schemas import (
     LoanStateResponse,
     OrderBookResponseModel,
 )
-from shared.constants import ProtocolIDs
+from shared.protocol_ids import ProtocolIDs
 
 logger = logging.getLogger(__name__)
 

--- a/apps/data_handler/tests/db_test/test_db_connector.py
+++ b/apps/data_handler/tests/db_test/test_db_connector.py
@@ -8,7 +8,7 @@ from data_handler.db.models import (
     LoanState,
     OrderBookModel,
 )
-from shared.constants import ProtocolIDs
+from shared.protocol_ids import ProtocolIDs
 from sqlalchemy.exc import SQLAlchemyError
 
 

--- a/apps/data_handler/tests/test_zklend_transformer.py
+++ b/apps/data_handler/tests/test_zklend_transformer.py
@@ -4,7 +4,7 @@ Test the zklend transformer
 
 import pytest
 from typing import Dict, Any
-from shared.constants import ProtocolIDs
+from shared.protocol_ids import ProtocolIDs
 from unittest.mock import patch
 from data_handler.handlers.events.zklend.transform_events import ZklendTransformer
 

--- a/apps/shared/constants.py
+++ b/apps/shared/constants.py
@@ -5,10 +5,10 @@ from dotenv import load_dotenv
 
 load_dotenv()
 from decimal import Decimal
-from enum import Enum
 from typing import List, Union
 
 from shared.custom_types import TokenSettings
+from shared.protocol_ids import ProtocolIDs
 
 CRONTAB_TIME = os.environ.get("CRONTAB_TIME", "1")
 
@@ -189,33 +189,6 @@ POOL_MAPPING: dict[str, dict[str, Union[List, str]]] = {
         "myswap_id": None,
     },
 }
-
-
-class ProtocolIDs(Enum):
-    """
-    This class contains the protocol IDs that are used in the system.
-    """
-
-    # hashstack protocols
-    HASHSTACK_V0: str = "Hashstack_v0"
-    HASHSTACK_V1: str = "Hashstack_v1"
-    HASHSTACK_V1_R: str = "Hashstack_v1_r"
-    HASHSTACK_V1_D: str = "Hashstack_v1_d"
-    # nostra protocols
-    NOSTRA_ALPHA: str = "Nostra_alpha"
-    NOSTRA_MAINNET: str = "Nostra_mainnet"
-    # zkLend protocol
-    ZKLEND: str = "zkLend"
-
-    VESU: str = "Vesu"
-
-    @classmethod
-    def choices(cls) -> list[str]:
-        """
-        This method returns the values of the enum.
-        :return: list of values
-        """
-        return [choice.value for choice in cls]
 
 
 # FIXME Uncomment when DAI is added correct address

--- a/apps/shared/protocol_ids.py
+++ b/apps/shared/protocol_ids.py
@@ -1,0 +1,20 @@
+from enum import Enum
+
+class ProtocolIDs(Enum):
+    """
+    This class contains the protocol IDs that are used in the system.
+    """
+    HASHSTACK: str = "Hashstack"
+    NOSTRA_ALPHA: str = "Nostra_alpha"
+    NOSTRA_MAINNET: str = "Nostra_mainnet"
+    ZKLEND: str = "zkLend"
+    VESU:str = "Vesu"
+
+    @classmethod
+    def choices(cls) -> list[str]:
+        """
+        This method returns the values of the enum.
+        :return: list of values
+        """
+        return [choice.value for choice in cls]
+

--- a/apps/shared/state/nostra/mainnet.py
+++ b/apps/shared/state/nostra/mainnet.py
@@ -11,7 +11,7 @@ from shared.loan_entity.nostra.mainnet import (
     NOSTRA_MAINNET_TOKEN_ADDRESSES,
 )
 from shared.helpers import get_symbol, get_addresses
-from shared.constants import ProtocolIDs
+from shared.protocol_ids import ProtocolIDs
 from shared.custom_types import (
     NostraDebtTokenParameters,
     NostraMainnetCollateralTokenParameters,

--- a/apps/shared/state/zklend.py
+++ b/apps/shared/state/zklend.py
@@ -3,7 +3,7 @@ import decimal
 import logging
 import pandas as pd
 from shared import blockchain_call
-from shared.constants import ProtocolIDs
+from shared.protocol_ids import ProtocolIDs
 from shared.helpers import add_leading_zeros, get_symbol
 from shared.data_parser.zklend import ZklendDataParser
 from typing import Optional, Protocol


### PR DESCRIPTION
This PR removes duplicate `ProtocolIDs` definitions and declares it in the shared folder.

Changes include:

- [x] Removed duplicate `ProtocolIDs` definitions.
- [x] Updated `ProtocolIDs` to the correct structure.
- [x] Moved `ProtocolIDs` to the shared folder.
- [x] Updated all imports across the project to reference the new location.

Closes #636 